### PR TITLE
Changing theme class to data attribute

### DIFF
--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -124,7 +124,7 @@
  * Colors for dark theme
  */
 
-:root.theme-dark {
+[data-theme='dark'] {
   --color-background-default: var(--brand-colors-grey-grey900);
   --color-background-alternative: var(--brand-colors-grey-grey800);
   --color-text-default: var(--brand-colors-white-white000);


### PR DESCRIPTION
# Description
Updating css stylesheet to use `[data-theme='dark']` instead of a `className` as I've see this in a few examples and seems to be best practice.

Technically this is a breaking change so semver dictates that this should update our package by a major version e.g. `2.0.0` 

