### PR TITLE
Add overlay alternative color

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -85,7 +85,7 @@ const colors = {
     },
     overlay: {
       default: '#FFFFFF40',
-      inverse: '#FCFCFC',
+      inverse: '#24272A',
       alternative: '#FFFFFF75',
     },
     primary: {

--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -20,6 +20,7 @@ const colors = {
     overlay: {
       default: '#00000060',
       inverse: '#FCFCFC',
+      alternative: '#00000075',
     },
     primary: {
       default: '#037DD6',
@@ -85,6 +86,7 @@ const colors = {
     overlay: {
       default: '#FFFFFF40',
       inverse: '#FCFCFC',
+      alternative: '#FFFFFF75',
     },
     primary: {
       default: '#1098FC',

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -86,7 +86,7 @@
   --color-border-default: var(--brand-colors-grey-grey200);
   --color-border-muted: var(--brand-colors-grey-grey100);
   --color-overlay-default: #00000060;
-  --color-overlay-alternative: #00000080;
+  --color-overlay-alternative: #00000075;
   --color-overlay-inverse: var(--brand-colors-white-white010);
   --color-primary-default: var(--brand-colors-blue-blue500);
   --color-primary-alternative: var(--brand-colors-blue-blue600);
@@ -136,7 +136,7 @@
   --color-border-default: var(--brand-colors-grey-grey400);
   --color-border-muted: var(--brand-colors-grey-grey700);
   --color-overlay-default: #ffffff40;
-  --color-overlay-alternative: #ffffff20;
+  --color-overlay-alternative: #ffffff75;
   --color-overlay-inverse: var(--brand-colors-white-white010);
   --color-primary-default: var(--brand-colors-blue-blue400);
   --color-primary-alternative: var(--brand-colors-blue-blue300);

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -137,7 +137,7 @@
   --color-border-muted: var(--brand-colors-grey-grey700);
   --color-overlay-default: #ffffff40;
   --color-overlay-alternative: #ffffff75;
-  --color-overlay-inverse: var(--brand-colors-white-white010);
+  --color-overlay-inverse: var(--brand-colors-grey-grey800);
   --color-primary-default: var(--brand-colors-blue-blue400);
   --color-primary-alternative: var(--brand-colors-blue-blue300);
   --color-primary-muted: #1098fc15;

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -86,6 +86,7 @@
   --color-border-default: var(--brand-colors-grey-grey200);
   --color-border-muted: var(--brand-colors-grey-grey100);
   --color-overlay-default: #00000060;
+  --color-overlay-alternative: #00000080;
   --color-overlay-inverse: var(--brand-colors-white-white010);
   --color-primary-default: var(--brand-colors-blue-blue500);
   --color-primary-alternative: var(--brand-colors-blue-blue600);
@@ -135,6 +136,7 @@
   --color-border-default: var(--brand-colors-grey-grey400);
   --color-border-muted: var(--brand-colors-grey-grey700);
   --color-overlay-default: #ffffff40;
+  --color-overlay-alternative: #ffffff20;
   --color-overlay-inverse: var(--brand-colors-white-white010);
   --color-primary-default: var(--brand-colors-blue-blue400);
   --color-primary-alternative: var(--brand-colors-blue-blue300);

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -385,6 +385,11 @@
           "description": "(black000: #000000 60% opacity) overlay.default should be used for all general overlay backgrounds",
           "type": "color"
         },
+        "alternative": {
+          "value": "#00000075",
+          "description": "(black000: #000000 75% opacity) overlay.alternative should be used for all general overlay backgrounds that need a higher contrast than overlay.default",
+          "type": "color"
+        },
         "inverse": {
           "value": "#FCFCFC",
           "description": "(white010: #FCFCFC) overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
@@ -614,6 +619,11 @@
         "default": {
           "value": "#FFFFFF40",
           "description": "(white000: #FFFFFF 40% opacity) overlay.default should be used for all general overlay backgrounds",
+          "type": "color"
+        },
+        "alternative": {
+          "value": "#FFFFFF75",
+          "description": "(white000: #FFFFFF 75% opacity) overlay.alternative should be used for all general overlay backgrounds that need a higher contrast than overlay.default",
           "type": "color"
         },
         "inverse": {

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -627,8 +627,8 @@
           "type": "color"
         },
         "inverse": {
-          "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
+          "value": "#24272A",
+          "description": "(grey800: #24272A) overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
           "type": "color"
         }
       },


### PR DESCRIPTION
Add missing overlay.alternative color and changing dark theme overlay.inverse to grey800: #24272A

## Screenshots

Light theme colors

<img width="1440" alt="Screen Shot 2022-03-02 at 9 34 18 AM" src="https://user-images.githubusercontent.com/8112138/156416726-0310d631-3290-44b4-9ad1-877dd95a6658.png">

Dark theme colors

<img width="1440" alt="Screen Shot 2022-03-02 at 10 04 31 AM" src="https://user-images.githubusercontent.com/8112138/156421477-dc25a715-a362-40c5-9362-427147a04faa.png">
