### PR TITLE
Fixing secondary default color for CSS in JS

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -96,7 +96,7 @@ const colors = {
       disabled: '#1098FC80',
     },
     secondary: {
-      default: '##F8883',
+      default: '#F8883B',
       alternative: '#FAA66C',
       muted: '#F8883B26',
       inverse: '#FCFCFC',


### PR DESCRIPTION
Fixing secondary default color typo for CSS in JS for dark theme

- checked all other secondary default token formats they seem to be correct

![Screen Shot 2022-03-18 at 11 46 44 AM](https://user-images.githubusercontent.com/8112138/159065435-317aefa3-c907-4177-839d-2e1a5a953b98.png)
