### PR TITLE
Updated Light Theme Color Token descriptions to the latest

### DIFF
--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -329,190 +329,190 @@
       "background": {
         "default": {
           "value": "#FFFFFF",
-          "description": "(white000: #FFFFFF) background.default should be used as the default background color for any neutral type components.",
+          "description": "(white000: #FFFFFF) For default neutral backgrounds.",
           "type": "color"
         },
         "alternative": {
           "value": "#F2F4F6",
-          "description": "(grey040: #F2F4F6) background.alternative should be used as an alternative background for any neutral type components that require some slight contrast to background.default",
+          "description": "(grey040: #F2F4F6) Added contrast option for neutral background. (Example: backdrop, header background)",
           "type": "color"
         }
       },
       "text": {
         "default": {
           "value": "#24272A",
-          "description": "(grey800: #24272A) text.default should be used for all general text used on background.default or background.alternative that takes main priority in the information hierarchy.",
+          "description": "(grey800: #24272A) For general text that takes main priority in the information hierarchy.",
           "type": "color"
         },
         "alternative": {
           "value": "#535A61",
-          "description": "(grey600: #535A61) text.alternative should be used for all general text used on background.default or background.alternative that takes less priority in the information hierarchy than text.default",
+          "description": "(grey600: #535A61) Weaker contrast option for neutral text. ",
           "type": "color"
         },
         "muted": {
           "value": "#BBC0C5",
-          "description": "(grey200: #BBC0C5) text.muted should be used for all low priority text used on background.default or background.alternative. These could also include placeholder or inactive text. It will also not meet AAA or AA accessibility standards.",
+          "description": "(grey200: #BBC0C5) For inactive or lowest-priority text. (Example: placeholder)",
           "type": "color"
         }
       },
       "icon": {
         "default": {
           "value": "#24272A",
-          "description": "(grey800: #24272A) icon.default should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative",
+          "description": "(grey800: #24272A) For default neutral icons.",
           "type": "color"
         },
         "muted": {
           "value": "#BBC0C5",
-          "description": "(grey200: #BBC0C5) icon.muted should be used for all low priority icon used on background.default or background.alternative. These could also include placeholder or inactive icons. It will also not meet AAA or AA accessibility standards.",
+          "description": "(grey200: #BBC0C5) For inactive icons.",
           "type": "color"
         }
       },
       "border": {
         "default": {
           "value": "#BBC0C5",
-          "description": "(grey200: #BBC0C5) border.default should be used for all neutral component border colors such as cards or inputs in default state.",
+          "description": "(grey200: #BBC0C5) For default neutral borders with visible contrast.",
           "type": "color"
         },
         "muted": {
           "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) border.muted should be used for any borders with low contrast or subtle definition like dividers",
+          "description": "(grey100: #D6D9DC) Weaker contrast option for neutral borders..",
           "type": "color"
         }
       },
       "overlay": {
         "default": {
           "value": "#00000099",
-          "description": "(black000: #000000 60% opacity) overlay.default should be used for all general overlay backgrounds",
+          "description": "(black000: #000000 60% opacity) For shading layers behind modality screens.",
           "type": "color"
         },
         "alternative": {
           "value": "#000000CC",
-          "description": "(black000: #000000 80% opacity) overlay.alternative should be used for all general overlay backgrounds that need a higher contrast than overlay.default",
+          "description": "(black000: #000000 80% opacity) Added contrast option of overlay.",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
+          "description": "(white010: #FCFCFC) [Deprecated] overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
           "type": "color"
         }
       },
       "primary": {
         "default": {
           "value": "#037DD6",
-          "description": "(blue500: #037DD6) primary.default should be used for all primary action components such as buttons or links.",
+          "description": "(blue500: #037DD6) For Interactive or active semantic",
           "type": "color"
         },
         "alternative": {
           "value": "#0260A4",
-          "description": "(blue600: #0260A4) primary.alternative should be used as an alternative to primary.default for things such as hover states",
+          "description": "(blue600: #0260A4) Reserved for \"pressed\" state on interactive elements.",
           "type": "color"
         },
         "muted": {
           "value": "#037DD619",
-          "description": "(blue500: #037DD6 10% opacity) primary.muted is a very low contrasting primary variant for things such as alert backgrounds. primary.muted and primary.inverse should not be used together in a foreground and background combination",
+          "description": "(blue500: #037DD6 10% opacity) Lowest contrast background used in primary semantic.",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) primary.inverse should be used only as the foreground element on top of primary.default and primary.alternative. It is intended to be the most contrasting color to primary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a primary button.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over primary fill. (Example: primary button label, check in a checkbox)",
           "type": "color"
         },
         "disabled": {
           "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) primary.disabled should be used for all disabled primary action components such as buttons or links.",
+          "description": "(blue500: #037DD6 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links.",
           "type": "color"
         }
       },
       "secondary": {
         "default": {
           "value": "#F66A0A",
-          "description": "(orange500: #F66A0A) secondary.default should be used for any secondary actions. It should not be used for any negative connotations such as warnings or errors as it is quite closely tied to the MetaMask Fox",
+          "description": "(orange500: #F66A0A) [Deprecated] secondary.default should be used for any secondary actions. It should not be used for any negative connotations such as warnings or errors as it is quite closely tied to the MetaMask Fox",
           "type": "color"
         },
         "alternative": {
           "value": "#C65507",
-          "description": "(orange600: #C65507) secondary.alternative should be used as an alternative to secondary.default for things such as hover states",
+          "description": "(orange600: #C65507) [Deprecated] secondary.alternative should be used as an alternative to secondary.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#F66A0A19",
-          "description": "(orange500: #F66A0A 10% opacity) secondary.muted is a very low contrasting secondary variant for things such as alert backgrounds. secondary.muted and secondary.inverse should not be used together in a foreground and background combination",
+          "description": "(orange500: #F66A0A 10% opacity) [Deprecated] secondary.muted is a very low contrasting secondary variant for things such as alert backgrounds. secondary.muted and secondary.inverse should not be used together in a foreground and background combination",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button.",
+          "description": "(white010: #FCFCFC) [Deprecated] secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button.",
           "type": "color"
         },
         "disabled": {
           "value": "#F66A0A80",
-          "description": "(orange500: #F66A0A 50% opacity) secondary.disabled should be used for all disabled secondary action components",
+          "description": "(orange500: #F66A0A 50% opacity) [Deprecated] secondary.disabled should be used for all disabled secondary action components",
           "type": "color"
         }
       },
       "error": {
         "default": {
           "value": "#D73A49",
-          "description": "(red500: #D73A49) error.default should be used for all error or critical action components such as buttons, icons or messages on background.default or background.alternative.",
+          "description": "(red500: #D73A49) For high-level alert semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#B92534",
-          "description": "(red600: #B92534) error.alternative should be used as an alternative to error.default for things such as hover states",
+          "description": "(red600: #B92534) Reserved for \"pressed\" state on interactive danger/error elements.",
           "type": "color"
         },
         "muted": {
           "value": "#D73A4919",
-          "description": "(red500: #D73A49 10% opacity) error.muted is a very low contrasting error variant for things such as alert backgrounds. error.muted and error.inverse should not be used together in a foreground and background combination",
+          "description": "(red500: #D73A49 10% opacity) For lowest contrast background in danger/error semantic. (Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) error.inverse should be used only as the foreground element on top of error.default and error.alternative. It is intended to be the most contrasting color to error.default. It should meet all AA and AAA accessibility standards such as the text of a critical action button.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over danger fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
           "value": "#D73A4980",
-          "description": "(red500: #D73A49 50% opacity) error.disabled should be used for all disabled critical action components such as buttons",
+          "description": "(red500: #D73A49 50% opacity) [Depreacted] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
       "warning": {
         "default": {
           "value": "#FFD33D",
-          "description": "(yellow500: #FFD33D) warning.default should be used for all warning or critical action components such as buttons, icons or messages on background.default or background.alternative.",
+          "description": "(yellow500: #FFD33D) For low-mid level alert semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#FFC70A",
-          "description": "(yellow600: #FFC70A) warning.alternative should be used as an alternative to warning.default for things such as hover states",
+          "description": "(yellow600: #FFC70A) [Deprecated] warning.alternative should be used as an alternative to warning.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#FFD33D19",
-          "description": "(yellow500: #FFD33D 10% opacity) warning.muted is a very low contrasting warning variant for things such as alert backgrounds. warning.muted and warning.inverse should not be used together in a foreground and background combination",
+          "description": "(yellow500: #FFD33D 10% opacity) Lowest contrast background used in warning semantic. (Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#141618",
-          "description": "(grey900: #141618) warning.inverse should be used only as the foreground element on top of warning.default and warning.alternative. It is intended to be the most contrasting color to warning.default. It should meet all AA and AAA accessibility standards",
+          "description": "(grey900: #141618) [Deprecated] warning.inverse should be used only as the foreground element on top of warning.default and warning.alternative. It is intended to be the most contrasting color to warning.default. It should meet all AA and AAA accessibility standards",
           "type": "color"
         },
         "disabled": {
           "value": "#FFD33D80",
-          "description": "(yellow500: #FFD33D 50% opacity) warning.disabled should be used for all disabled component colors such as buttons",
+          "description": "(yellow500: #FFD33D 50% opacity) [Deprecated] warning.disabled should be used for all disabled component colors such as buttons",
           "type": "color"
         }
       },
       "success": {
         "default": {
           "value": "#28A745",
-          "description": "(green500: #28A745) success.default should be used for all success states such as icons messages.",
+          "description": "(green500: #28A745) For positive & good semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#1E7E34",
-          "description": "(green600: #1E7E34) success.alternative should be used as an alternative to success.default for things such as hover states",
+          "description": "(green600: #1E7E34) Lowest contrast background used in success semantic. (Example: Notification background)",
           "type": "color"
         },
         "muted": {
@@ -522,39 +522,39 @@
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) success.inverse should be used only as the foreground element on top of success.default and success.alternative. It is intended to be the most contrasting color to success.default. It should meet all AA and AAA accessibility standards",
+          "description": "(white010: #FCFCFC) [Deprecated] success.inverse should be used only as the foreground element on top of success.default and success.alternative. It is intended to be the most contrasting color to success.default. It should meet all AA and AAA accessibility standards",
           "type": "color"
         },
         "disabled": {
           "value": "#28A74580",
-          "description": "(green500: #28A745 50% opacity) success.disabled should be used for all disabled success component colors such as buttons",
+          "description": "(green500: #28A745 50% opacity) [Deprecated] success.disabled should be used for all disabled success component colors such as buttons",
           "type": "color"
         }
       },
       "info": {
         "default": {
           "value": "#037DD6",
-          "description": "(blue500: #037DD6) info.default should be used for all info action components such as buttons or links.",
+          "description": "(blue500: #037DD6) For informational semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#0260A4",
-          "description": "(blue600: #0260A4) info.alternative should be used as an alternative to info.default for things such as hover states",
+          "description": "(blue600: #0260A4) [Deprecated] info.alternative should be used as an alternative to info.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#037DD619",
-          "description": "(blue500: #037DD6 10% opacity) info.muted is a very low contrasting info variant for things such as alert backgrounds. info.muted and info.inverse should not be used together in a foreground and background combination",
+          "description": "(blue500: #037DD6 10% opacity) Lowest contrast background used in info semantic.(Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) info.inverse should be used only as the foreground element on top of info.default and info.alternative. It is intended to be the most contrasting color to info.default. It should meet all AA and AAA accessibility standards such as the text or icon of a info button.",
+          "description": "(white010: #FCFCFC) [Deprecated] info.inverse should be used only as the foreground element on top of info.default and info.alternative. It is intended to be the most contrasting color to info.default. It should meet all AA and AAA accessibility standards such as the text or icon of a info button.",
           "type": "color"
         },
         "disabled": {
           "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) primary.disabled should be used for all disabled primary action components such as buttons or links.",
+          "description": "(blue500: #037DD6 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links.",
           "type": "color"
         }
       }

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -329,65 +329,65 @@
       "background": {
         "default": {
           "value": "#FFFFFF",
-          "description": "(white000: #FFFFFF) For default neutral backgrounds.",
+          "description": "(white000: #FFFFFF) For default neutral backgrounds",
           "type": "color"
         },
         "alternative": {
           "value": "#F2F4F6",
-          "description": "(grey040: #F2F4F6) Added contrast option for neutral background. (Example: backdrop, header background)",
+          "description": "(grey040: #F2F4F6) For a subtle contrast option for neutral backgrounds. (Example: backdrop, header background)",
           "type": "color"
         }
       },
       "text": {
         "default": {
           "value": "#24272A",
-          "description": "(grey800: #24272A) For general text that takes main priority in the information hierarchy.",
+          "description": "(grey800: #24272A) For general text that takes main priority in the information hierarchy",
           "type": "color"
         },
         "alternative": {
           "value": "#535A61",
-          "description": "(grey600: #535A61) Weaker contrast option for neutral text. ",
+          "description": "(grey600: #535A61) For a weaker contrast option for neutral text",
           "type": "color"
         },
         "muted": {
           "value": "#BBC0C5",
-          "description": "(grey200: #BBC0C5) For inactive or lowest-priority text. (Example: placeholder)",
+          "description": "(grey200: #BBC0C5) For inactive or lowest priority text. (Example: placeholder)",
           "type": "color"
         }
       },
       "icon": {
         "default": {
           "value": "#24272A",
-          "description": "(grey800: #24272A) For default neutral icons.",
+          "description": "(grey800: #24272A) For default neutral icons",
           "type": "color"
         },
         "muted": {
           "value": "#BBC0C5",
-          "description": "(grey200: #BBC0C5) For inactive icons.",
+          "description": "(grey200: #BBC0C5) For inactive or lowest priority icons",
           "type": "color"
         }
       },
       "border": {
         "default": {
           "value": "#BBC0C5",
-          "description": "(grey200: #BBC0C5) For default neutral borders with visible contrast.",
+          "description": "(grey200: #BBC0C5) For default neutral borders with visible contrast. (Example: text inputs)",
           "type": "color"
         },
         "muted": {
           "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) Weaker contrast option for neutral borders..",
+          "description": "(grey100: #D6D9DC) For a weaker contrast option for neutral borders. (Example: dividers)",
           "type": "color"
         }
       },
       "overlay": {
         "default": {
           "value": "#00000099",
-          "description": "(black000: #000000 60% opacity) For shading layers behind modality screens.",
+          "description": "(black000: #000000 60% opacity) For shading layers behind modality screens",
           "type": "color"
         },
         "alternative": {
           "value": "#000000CC",
-          "description": "(black000: #000000 80% opacity) Added contrast option of overlay.",
+          "description": "(black000: #000000 80% opacity) For a stronger shading layer option behind modality screens",
           "type": "color"
         },
         "inverse": {
@@ -399,27 +399,27 @@
       "primary": {
         "default": {
           "value": "#037DD6",
-          "description": "(blue500: #037DD6) For Interactive or active semantic",
+          "description": "(blue500: #037DD6) For primary user action related elements",
           "type": "color"
         },
         "alternative": {
           "value": "#0260A4",
-          "description": "(blue600: #0260A4) Reserved for \"pressed\" state on interactive elements.",
+          "description": "(blue600: #0260A4) For the \"pressed\" state of interactive primary elements",
           "type": "color"
         },
         "muted": {
           "value": "#037DD619",
-          "description": "(blue500: #037DD6 10% opacity) Lowest contrast background used in primary semantic.",
+          "description": "(blue500: #037DD6 10% opacity) For lowest contrast background used in primary elements",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over primary fill. (Example: primary button label, check in a checkbox)",
+          "description": "(white010: #FCFCFC) For elements used on top of primary/default. (Example: label of primary button, check in a checkbox)",
           "type": "color"
         },
         "disabled": {
           "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links.",
+          "description": "(blue500: #037DD6 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       },
@@ -441,7 +441,7 @@
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) [Deprecated] secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button.",
+          "description": "(white010: #FCFCFC) [Deprecated] secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button",
           "type": "color"
         },
         "disabled": {
@@ -453,34 +453,34 @@
       "error": {
         "default": {
           "value": "#D73A49",
-          "description": "(red500: #D73A49) For high-level alert semantic. Used on text, background, icon, border.",
+          "description": "(red500: #D73A49) For high-level alert danger/critical elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
           "value": "#B92534",
-          "description": "(red600: #B92534) Reserved for \"pressed\" state on interactive danger/error elements.",
+          "description": "(red600: #B92534) For the \"pressed\" state of interactive danger/critical elements",
           "type": "color"
         },
         "muted": {
           "value": "#D73A4919",
-          "description": "(red500: #D73A49 10% opacity) For lowest contrast background in danger/error semantic. (Example: Notification background)",
+          "description": "(red500: #D73A49 10% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over error/danger fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) For elements used on top of error/default (Example: label of danger/critical button)",
           "type": "color"
         },
         "disabled": {
           "value": "#D73A4980",
-          "description": "(red500: #D73A49 50% opacity) [Depreacted] error.disabled should be used for all disabled critical action components such as buttons",
+          "description": "(red500: #D73A49 50% opacity) [Deprecated] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
       "warning": {
         "default": {
           "value": "#FFD33D",
-          "description": "(yellow500: #FFD33D) For low-mid level alert semantic. Used on text, background, icon, border.",
+          "description": "(yellow500: #FFD33D) For low-mid level alert elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -490,12 +490,12 @@
         },
         "muted": {
           "value": "#FFD33D19",
-          "description": "(yellow500: #FFD33D 10% opacity) Lowest contrast background used in warning semantic. (Example: Notification background)",
+          "description": "(yellow500: #FFD33D 10% opacity) For lowest contrast background used in warning elements. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#141618",
-          "description": "(grey900: #141618) Reserved for elements used over warning fill. Used on text, icon, border.",
+          "description": "(grey900: #141618) For elements used on top of warning/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {
@@ -507,7 +507,7 @@
       "success": {
         "default": {
           "value": "#28A745",
-          "description": "(green500: #28A745) For positive & good semantic. Used on text, background, icon, border.",
+          "description": "(green500: #28A745) For positive & good semantic elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -517,12 +517,12 @@
         },
         "muted": {
           "value": "#28A74519",
-          "description": "(green500: #28A74519 10% opacity) Lowest contrast background used in success semantic. (Example: Notification background)",
+          "description": "(green500: #28A74519 10% opacity) For lowest contrast background used in success semantic. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over success fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) For elements used on top of success/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {
@@ -534,7 +534,7 @@
       "info": {
         "default": {
           "value": "#037DD6",
-          "description": "(blue500: #037DD6) For informational semantic. Used on text, background, icon, border.",
+          "description": "(blue500: #037DD6) For informational semantic elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -544,17 +544,17 @@
         },
         "muted": {
           "value": "#037DD619",
-          "description": "(blue500: #037DD6 10% opacity) Lowest contrast background used in info semantic.(Example: Notification background)",
+          "description": "(blue500: #037DD6 10% opacity) For lowest contrast background used in informational semantic. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over info fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) For elements used on top of info/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {
           "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links.",
+          "description": "(blue500: #037DD6 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       }
@@ -565,65 +565,65 @@
       "background": {
         "default": {
           "value": "#24272A",
-          "description": "(grey800: #24272A) For default neutral backgrounds.",
+          "description": "(grey800: #24272A) For default neutral backgrounds",
           "type": "color"
         },
         "alternative": {
           "value": "#141618",
-          "description": "(grey900: #141618) Added contrast option for neutral background. (Example: backdrop, header background)",
+          "description": "(grey900: #141618) For a subtle contrast option for neutral backgrounds. (Example: backdrop, header background)",
           "type": "color"
         }
       },
       "text": {
         "default": {
           "value": "#FFFFFF",
-          "description": "(white000: #FFFFFF) For general text that takes main priority in the information hierarchy.",
+          "description": "(white000: #FFFFFF) For general text that takes main priority in the information hierarchy",
           "type": "color"
         },
         "alternative": {
           "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) Weaker contrast option for neutral text. ",
+          "description": "(grey100: #D6D9DC) For a weaker contrast option for neutral text. ",
           "type": "color"
         },
         "muted": {
           "value": "#9FA6AE",
-          "description": "(grey300: #9FA6AE) For inactive or lowest-priority text. (Example: placeholder)",
+          "description": "(grey300: #9FA6AE) For inactive or lowest priority text. (Example: placeholder)",
           "type": "color"
         }
       },
       "icon": {
         "default": {
           "value": "#FFFFFF",
-          "description": "(white000: #FFFFFF) For default neutral icons.",
+          "description": "(white000: #FFFFFF) For default neutral icons",
           "type": "color"
         },
         "muted": {
           "value": "#9FA6AE",
-          "description": "(grey300: #9FA6AE) For inactive icons.",
+          "description": "(grey300: #9FA6AE) For inactive or lowest priority icons",
           "type": "color"
         }
       },
       "border": {
         "default": {
           "value": "#848C96",
-          "description": "(grey400: #848C96) For default neutral borders with visible contrast.",
+          "description": "(grey400: #848C96) For default neutral borders with visible contrast. (Example: text inputs)",
           "type": "color"
         },
         "muted": {
           "value": "#3B4046",
-          "description": "(grey700: #3B4046) Weaker contrast option for neutral borders.",
+          "description": "(grey700: #3B4046) For a weaker contrast option for neutral borders. (Example: dividers)",
           "type": "color"
         }
       },
       "overlay": {
         "default": {
           "value": "#00000099",
-          "description": "(black000: #000000 60% opacity) For shading layers behind modality screens.",
+          "description": "(black000: #000000 60% opacity) For shading layers behind modality screens",
           "type": "color"
         },
         "alternative": {
           "value": "#000000CC",
-          "description": "(black000: #000000 80% opacity) Added contrast option of overlay.",
+          "description": "(black000: #000000 80% opacity) For a stronger shading layer option behind modality screens",
           "type": "color"
         },
         "inverse": {
@@ -635,27 +635,27 @@
       "primary": {
         "default": {
           "value": "#1098FC",
-          "description": "(blue400: #1098FC) For Interactive or active semantic",
+          "description": "(blue400: #1098FC) For primary user action related elements",
           "type": "color"
         },
         "alternative": {
           "value": "#43AEFC",
-          "description": "(blue300: #43AEFC) Reserved for \"pressed\" state on interactive elements.",
+          "description": "(blue300: #43AEFC) For the \"pressed\" state of interactive primary elements",
           "type": "color"
         },
         "muted": {
           "value": "#1098FC26",
-          "description": "(blue400: #1098FC 15% opacity) Lowest contrast background used in primary semantic.",
+          "description": "(blue400: #1098FC 15% opacity) For lowest contrast background used in primary elements",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over primary fill. (Example: primary button label, check in a checkbox)",
+          "description": "(white010: #FCFCFC) For elements used on top of primary/default. (Example: label of primary button, check in a checkbox)",
           "type": "color"
         },
         "disabled": {
           "value": "#1098FC80",
-          "description": "(blue400: #1098FC) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links.",
+          "description": "(blue400: #1098FC) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       },
@@ -677,7 +677,7 @@
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) [Deprecated] secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button.",
+          "description": "(white010: #FCFCFC) [Deprecated] secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button",
           "type": "color"
         },
         "disabled": {
@@ -689,34 +689,34 @@
       "error": {
         "default": {
           "value": "#D73A49",
-          "description": "(red500: #D73A49) For high-level alert semantic. Used on text, background, icon, border.",
+          "description": "(red500: #D73A49) For high-level alert danger/critical elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
           "value": "#E06470",
-          "description": "(red400: #E06470) Reserved for \"pressed\" state on interactive danger/error elements.",
+          "description": "(red400: #E06470) For the \"pressed\" state of interactive danger/critical elements",
           "type": "color"
         },
         "muted": {
           "value": "#D73A4926",
-          "description": "(red500: #D73A49 15% opacity)  For lowest contrast background in danger/error semantic. (Example: Notification background)",
+          "description": "(red500: #D73A49 15% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over danger fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) For elements used on top of error/default (Example: label of danger/critical button)",
           "type": "color"
         },
         "disabled": {
           "value": "#D73A4980",
-          "description": "(red500: #D73A49 50% opacity) [Depreacted] error.disabled should be used for all disabled critical action components such as buttons",
+          "description": "(red500: #D73A49 50% opacity) [Deprecated] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
       "warning": {
         "default": {
           "value": "#FFD33D",
-          "description": "(yellow500: #FFD33D) For low-mid level alert semantic. Used on text, background, icon, border.",
+          "description": "(yellow500: #FFD33D) For low-mid level alert elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -726,12 +726,12 @@
         },
         "muted": {
           "value": "#FFD33D26",
-          "description": "(yellow500: #FFD33D 15% opacity) Lowest contrast background used in warning semantic. (Example: Notification background)",
+          "description": "(yellow500: #FFD33D 15% opacity) For lowest contrast background used in warning elements. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#141618",
-          "description": "(grey900: #141618)  Reserved for elements used over warning fill. Used on text, icon, border.",
+          "description": "(grey900: #141618) For elements used on top of warning/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {
@@ -743,7 +743,7 @@
       "success": {
         "default": {
           "value": "#28A745",
-          "description": "(green500: #28A745) For positive & good semantic. Used on text, background, icon, border.",
+          "description": "(green500: #28A745) For positive & good semantic elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -753,12 +753,12 @@
         },
         "muted": {
           "value": "#28A74526",
-          "description": "(green500: #28A745 15% opacity) Lowest contrast background used in success semantic. (Example: Notification background)",
+          "description": "(green500: #28A745 15% opacity) Lowest contrast background used in success semantic. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over success fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) For elements used on top of success/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {
@@ -770,7 +770,7 @@
       "info": {
         "default": {
           "value": "#1098FC",
-          "description": "(blue400: #1098FC) info.default should be used for all info action components such as buttons or links.",
+          "description": "(blue400: #1098FC) For informational semantic elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -780,17 +780,17 @@
         },
         "muted": {
           "value": "#1098FC26",
-          "description": "(blue400: #1098FC 15% opacity) Lowest contrast background used in info semantic.(Example: Notification background)",
+          "description": "(blue400: #1098FC 15% opacity) For lowest contrast background used in informational semantic. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over info fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) For elements used on top of info/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {
           "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) [Deprecated] info.disabled should be used for all disabled info action components such as buttons or links.",
+          "description": "(blue500: #037DD6 50% opacity) [Deprecated] info.disabled should be used for all disabled info action components such as buttons or links",
           "type": "color"
         }
       }

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -512,12 +512,12 @@
         },
         "alternative": {
           "value": "#1E7E34",
-          "description": "(green600: #1E7E34) Lowest contrast background used in success semantic. (Example: Notification background)",
+          "description": "(green600: #1E7E34) [Deprecated] (green600: #1E7E34) success.alternative should be used as an alternative to success.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#28A74519",
-          "description": "(green500: #28A745 10% opacity) success.muted is a very low contrasting success variant for things such as alert backgrounds. success.muted and success.inverse should not be used together in a foreground and background combination",
+          "description": "(green500: #28A74519 10% opacity) Lowest contrast background used in success semantic. (Example: Notification background)",
           "type": "color"
         },
         "inverse": {

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -468,7 +468,7 @@
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) Reserved for elements used over danger fill. Used on text, icon, border.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over error/danger fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
@@ -495,7 +495,7 @@
         },
         "inverse": {
           "value": "#141618",
-          "description": "(grey900: #141618) [Deprecated] warning.inverse should be used only as the foreground element on top of warning.default and warning.alternative. It is intended to be the most contrasting color to warning.default. It should meet all AA and AAA accessibility standards",
+          "description": "(grey900: #141618) Reserved for elements used over warning fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
@@ -522,7 +522,7 @@
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) [Deprecated] success.inverse should be used only as the foreground element on top of success.default and success.alternative. It is intended to be the most contrasting color to success.default. It should meet all AA and AAA accessibility standards",
+          "description": "(white010: #FCFCFC) Reserved for elements used over success fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
@@ -549,7 +549,7 @@
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) [Deprecated] info.inverse should be used only as the foreground element on top of info.default and info.alternative. It is intended to be the most contrasting color to info.default. It should meet all AA and AAA accessibility standards such as the text or icon of a info button.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over info fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
@@ -565,205 +565,205 @@
       "background": {
         "default": {
           "value": "#24272A",
-          "description": "(grey800: #24272A) background.default should be used as the default background color for any neutral type components.",
+          "description": "(grey800: #24272A) For default neutral backgrounds.",
           "type": "color"
         },
         "alternative": {
           "value": "#141618",
-          "description": "(grey900: #141618) background.alternative should be used as an alternative background for any neutral type components that require some slight contrast to background.default.",
+          "description": "(grey900: #141618) Added contrast option for neutral background. (Example: backdrop, header background)",
           "type": "color"
         }
       },
       "text": {
         "default": {
           "value": "#FFFFFF",
-          "description": "(white000: #FFFFFF) text.default should be used for all general text used on background.default or background.alternative that takes main priority in the information hierarchy.",
+          "description": "(white000: #FFFFFF) For general text that takes main priority in the information hierarchy.",
           "type": "color"
         },
         "alternative": {
           "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) text.alternative should be used for all general text used on background.default or background.alternative that takes less priority in the information hierarchy than text.default",
+          "description": "(grey100: #D6D9DC) Weaker contrast option for neutral text. ",
           "type": "color"
         },
         "muted": {
           "value": "#9FA6AE",
-          "description": "(grey300: #9FA6AE) text.muted should be used for all low priority text used on background.default or background.alternative. These could also include placeholder or inactive text. It will also not meet AAA or AA accessibility standards.",
+          "description": "(grey300: #9FA6AE) For inactive or lowest-priority text. (Example: placeholder)",
           "type": "color"
         }
       },
       "icon": {
         "default": {
           "value": "#FFFFFF",
-          "description": "(white000: #FFFFFF) icon.default should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative",
+          "description": "(white000: #FFFFFF) For default neutral icons.",
           "type": "color"
         },
         "muted": {
           "value": "#9FA6AE",
-          "description": "(grey300: #9FA6AE) icon.muted should be used for all low priority icon used on background.default or background.alternative. These could also include placeholder or inactive icons. It will also not meet AAA or AA accessibility standards.",
+          "description": "(grey300: #9FA6AE) For inactive icons.",
           "type": "color"
         }
       },
       "border": {
         "default": {
           "value": "#848C96",
-          "description": "(grey400: #848C96) border.default should be used for all neutral component border colors such as cards or inputs in default state.",
+          "description": "(grey400: #848C96) For default neutral borders with visible contrast.",
           "type": "color"
         },
         "muted": {
           "value": "#3B4046",
-          "description": "(grey700: #3B4046) border.muted should be used for any borders with low contrast or subtle definition like dividers",
+          "description": "(grey700: #3B4046) Weaker contrast option for neutral borders.",
           "type": "color"
         }
       },
       "overlay": {
         "default": {
           "value": "#00000099",
-          "description": "(black000: #000000 60% opacity) overlay.default should be used for all general overlay backgrounds",
+          "description": "(black000: #000000 60% opacity) For shading layers behind modality screens.",
           "type": "color"
         },
         "alternative": {
           "value": "#000000CC",
-          "description": "(black000: #000000 80% opacity) overlay.alternative should be used for all general overlay backgrounds that need a higher contrast than overlay.default",
+          "description": "(black000: #000000 80% opacity) Added contrast option of overlay.",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
+          "description": "(white010: #FCFCFC) [Deprecated] overlay.inverse should be used only as the foreground element on top of overlay.default used for text or icons",
           "type": "color"
         }
       },
       "primary": {
         "default": {
           "value": "#1098FC",
-          "description": "(blue400: #1098FC) primary.default should be used for all primary action components such as buttons or links.",
+          "description": "(blue400: #1098FC) For Interactive or active semantic",
           "type": "color"
         },
         "alternative": {
           "value": "#43AEFC",
-          "description": "(blue300: #43AEFC) primary.alternative should be used as an alternative to primary.default for things such as hover states",
+          "description": "(blue300: #43AEFC) Reserved for \"pressed\" state on interactive elements.",
           "type": "color"
         },
         "muted": {
           "value": "#1098FC26",
-          "description": "(blue400: #1098FC 15% opacity) primary.muted is a very low contrasting primary variant for things such as alert backgrounds. primary.muted and primary.inverse should not be used together in a foreground and background combination",
+          "description": "(blue400: #1098FC 15% opacity) Lowest contrast background used in primary semantic.",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) primary.inverse should be used only as the foreground element on top of primary.default and primary.alternative. It is intended to be the most contrasting color to primary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a primary button.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over primary fill. (Example: primary button label, check in a checkbox)",
           "type": "color"
         },
         "disabled": {
           "value": "#1098FC80",
-          "description": "(blue400: #1098FC) 50% opacity) primary.disabled should be used for all disabled primary action components such as buttons or links.",
+          "description": "(blue400: #1098FC) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links.",
           "type": "color"
         }
       },
       "secondary": {
         "default": {
           "value": "#F8883B",
-          "description": "(orange400: #F8883B) secondary.default should be used for any secondary actions. It should not be used for any negative connotations such as warnings or errors as it is quite closely tied to the MetaMask Fox",
+          "description": "(orange400: #F8883B) [Deprecated] secondary.default should be used for any secondary actions. It should not be used for any negative connotations such as warnings or errors as it is quite closely tied to the MetaMask Fox",
           "type": "color"
         },
         "alternative": {
           "value": "#FAA66C",
-          "description": "(orange300: #FAA66C) secondary.alternative should be used as an alternative to secondary.default for things such as hover states",
+          "description": "(orange300: #FAA66C) [Deprecated] secondary.alternative should be used as an alternative to secondary.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#F8883B26",
-          "description": "(orange400: #F8883B 15% opacity) secondary.muted is a very low contrasting secondary variant for things such as alert backgrounds. secondary.muted and secondary.inverse should not be used together in a foreground and background combination",
+          "description": "(orange400: #F8883B 15% opacity) [Deprecated] secondary.muted is a very low contrasting secondary variant for things such as alert backgrounds. secondary.muted and secondary.inverse should not be used together in a foreground and background combination",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button.",
+          "description": "(white010: #FCFCFC) [Deprecated] secondary.inverse should be used only as the foreground element on top of secondary.default and secondary.alternative. It is intended to be the most contrasting color to secondary.default. It should meet all AA and AAA accessibility standards such as the text or icon of a secondary button.",
           "type": "color"
         },
         "disabled": {
           "value": "#F8883B80",
-          "description": "(orange400: #F8883B 50% opacity) secondary.disabled should be used for all disabled secondary action components",
+          "description": "(orange400: #F8883B 50% opacity) [Deprecated] secondary.disabled should be used for all disabled secondary action components",
           "type": "color"
         }
       },
       "error": {
         "default": {
           "value": "#D73A49",
-          "description": "(red500: #D73A49) error.default should be used for all error or critical action components such as buttons, icons or messages on background.default or background.alternative.",
+          "description": "(red500: #D73A49) For high-level alert semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#E06470",
-          "description": "(red400: #E06470) error.alternative should be used as an alternative to error.default for things such as hover states",
+          "description": "(red400: #E06470) Reserved for \"pressed\" state on interactive danger/error elements.",
           "type": "color"
         },
         "muted": {
           "value": "#D73A4926",
-          "description": "(red500: #D73A49 15% opacity) error.muted is a very low contrasting error variant for things such as alert backgrounds. error.muted and error.inverse should not be used together in a foreground and background combination",
+          "description": "(red500: #D73A49 15% opacity)  For lowest contrast background in danger/error semantic. (Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) error.inverse should be used only as the foreground element on top of error.default and error.alternative. It is intended to be the most contrasting color to error.default. It should meet all AA and AAA accessibility standards such as the text of a critical action button.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over danger fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
           "value": "#D73A4980",
-          "description": "(red500: #D73A49 50% opacity) error.disabled should be used for all disabled critical action components such as buttons",
+          "description": "(red500: #D73A49 50% opacity) [Depreacted] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
       "warning": {
         "default": {
           "value": "#FFD33D",
-          "description": "(yellow500: #FFD33D) warning.default should be used for all warning or critical action components such as buttons, icons or messages on background.default or background.alternative.",
+          "description": "(yellow500: #FFD33D) For low-mid level alert semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#FFDF70",
-          "description": "(yellow400: #FFDF70) warning.alternative should be used as an alternative to warning.default for things such as hover states",
+          "description": "(yellow400: #FFDF70) [Deprecated] warning.alternative should be used as an alternative to warning.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#FFD33D26",
-          "description": "(yellow500: #FFD33D 15% opacity) warning.muted is a very low contrasting warning variant for things such as alert backgrounds. warning.muted and warning.inverse should not be used together in a foreground and background combination",
+          "description": "(yellow500: #FFD33D 15% opacity) Lowest contrast background used in warning semantic. (Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#141618",
-          "description": "(grey900: #141618) warning.inverse should be used only as the foreground element on top of warning.default and warning.alternative. It is intended to be the most contrasting color to warning.default. It should meet all AA and AAA accessibility standards",
+          "description": "(grey900: #141618)  Reserved for elements used over warning fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
           "value": "#FFD33D80",
-          "description": "(yellow500: #FFD33D 50% opacity) warning.disabled should be used for all disabled component colors such as buttons",
+          "description": "(yellow500: #FFD33D 50% opacity) [Deprecated] warning.disabled should be used for all disabled component colors such as buttons",
           "type": "color"
         }
       },
       "success": {
         "default": {
           "value": "#28A745",
-          "description": "(green500: #28A745) success.default should be used for all success states such as icons messages.",
+          "description": "(green500: #28A745) For positive & good semantic. Used on text, background, icon, border.",
           "type": "color"
         },
         "alternative": {
           "value": "#5DD879",
-          "description": "(green400: #5DD879) success.alternative should be used as an alternative to success.default for things such as hover states",
+          "description": "(green400: #5DD879) [Deprecated] success.alternative should be used as an alternative to success.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#28A74526",
-          "description": "(green500: #28A745 15% opacity) success.muted is a very low contrasting success variant for things such as alert backgrounds. success.muted and success.inverse should not be used together in a foreground and background combination",
+          "description": "(green500: #28A745 15% opacity) Lowest contrast background used in success semantic. (Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) success.inverse should be used only as the foreground element on top of success.default and success.alternative. It is intended to be the most contrasting color to success.default. It should meet all AA and AAA accessibility standards",
+          "description": "(white010: #FCFCFC) Reserved for elements used over success fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
           "value": "#28A74580",
-          "description": "(green500: #28A745 50% opacity) success.disabled should be used for all disabled success component colors such as buttons",
+          "description": "(green500: #28A745 50% opacity) [Deprecated] success.disabled should be used for all disabled success component colors such as buttons",
           "type": "color"
         }
       },
@@ -775,22 +775,22 @@
         },
         "alternative": {
           "value": "#43AEFC",
-          "description": "(blue300: #43AEFC) info.alternative should be used as an alternative to info.default for things such as hover states",
+          "description": "(blue300: #43AEFC) [Deprecated] info.alternative should be used as an alternative to info.default for things such as hover states",
           "type": "color"
         },
         "muted": {
           "value": "#1098FC26",
-          "description": "(blue400: #1098FC 15% opacity) info.muted is a very low contrasting info variant for things such as alert backgrounds. info.muted and info.inverse should not be used together in a foreground and background combination",
+          "description": "(blue400: #1098FC 15% opacity) Lowest contrast background used in info semantic.(Example: Notification background)",
           "type": "color"
         },
         "inverse": {
           "value": "#FCFCFC",
-          "description": "(white010: #FCFCFC) info.inverse should be used only as the foreground element on top of info.default and info.alternative. It is intended to be the most contrasting color to info.default. It should meet all AA and AAA accessibility standards such as the text or icon of a info button.",
+          "description": "(white010: #FCFCFC) Reserved for elements used over info fill. Used on text, icon, border.",
           "type": "color"
         },
         "disabled": {
           "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) info.disabled should be used for all disabled info action components such as buttons or links.",
+          "description": "(blue500: #037DD6 50% opacity) [Deprecated] info.disabled should be used for all disabled info action components such as buttons or links.",
           "type": "color"
         }
       }


### PR DESCRIPTION
Closes: https://github.com/MetaMask/design-tokens/issues/59

Updated Light Theme color token descriptions to reflect our latest usage practice guide. This is so we can help designers to apply color tokens correctly following our practices when building new components.

* Colors we no longer wish to support are prefixed with "[Deprecated]" with the old description in tact.
* HEX values are NOT subject to the updates for this PR. They all remain the same.
* Once review is done, I'll make the same update on the Dark Theme.

The latest descriptions are also viewable in the Figma file
https://www.figma.com/file/kdFzEC7xzSNw7cXteqgzDW/%5BColor%5D-Light-Theme?node-id=0%3A1