### PR TITLE
Color update: icon/default and text/alternative

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -141,7 +141,7 @@ const colors: Colors = {
       muted: '#BBC0C5',
     },
     icon: {
-      default: '#6A737D',
+      default: '#24272A',
       muted: '#BBC0C5',
     },
     border: {
@@ -203,11 +203,11 @@ const colors: Colors = {
     },
     text: {
       default: '#FFFFFF',
-      alternative: '#FAFBFC',
+      alternative: '#D6D9DC',
       muted: '#9FA6AE',
     },
     icon: {
-      default: '#F2F4F6',
+      default: '#FFFFFF',
       muted: '#9FA6AE',
     },
     border: {

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -81,7 +81,7 @@
   --color-text-default: var(--brand-colors-grey-grey800);
   --color-text-alternative: var(--brand-colors-grey-grey600);
   --color-text-muted: var(--brand-colors-grey-grey200);
-  --color-icon-default: var(--brand-colors-grey-grey500);
+  --color-icon-default: var(--brand-colors-grey-grey800);
   --color-icon-muted: var(--brand-colors-grey-grey200);
   --color-border-default: var(--brand-colors-grey-grey200);
   --color-border-muted: var(--brand-colors-grey-grey100);
@@ -129,9 +129,9 @@
   --color-background-default: var(--brand-colors-grey-grey800);
   --color-background-alternative: var(--brand-colors-grey-grey900);
   --color-text-default: var(--brand-colors-white-white000);
-  --color-text-alternative: var(--brand-colors-grey-grey030);
+  --color-text-alternative: var(--brand-colors-grey-grey100);
   --color-text-muted: var(--brand-colors-grey-grey400);
-  --color-icon-default: var(--brand-colors-grey-grey040);
+  --color-icon-default: var(--brand-colors-white-white000);
   --color-icon-muted: var(--brand-colors-grey-grey400);
   --color-border-default: var(--brand-colors-grey-grey400);
   --color-border-muted: var(--brand-colors-grey-grey700);

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -357,8 +357,8 @@
       },
       "icon": {
         "default": {
-          "value": "#6A737D",
-          "description": "(grey500: #6A737D) icon.default should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative",
+          "value": "#24272A",
+          "description": "(grey800: #24272A) icon.default should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative",
           "type": "color"
         },
         "muted": {
@@ -581,8 +581,8 @@
           "type": "color"
         },
         "alternative": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) text.alternative should be used for all general text used on background.default or background.alternative that takes less priority in the information hierarchy than text.default",
+          "value": "#D6D9DC",
+          "description": "(grey100: #D6D9DC) text.alternative should be used for all general text used on background.default or background.alternative that takes less priority in the information hierarchy than text.default",
           "type": "color"
         },
         "muted": {
@@ -593,8 +593,8 @@
       },
       "icon": {
         "default": {
-          "value": "#F2F4F6",
-          "description": "(grey040: #F2F4F6) icon.default should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative",
+          "value": "#FFFFFF",
+          "description": "(white000: #FFFFFF) icon.default should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative",
           "type": "color"
         },
         "muted": {


### PR DESCRIPTION
### Description
Updating colors:
Light theme icon/default from: grey500: #6A737D => grey800: #24272A
Dark theme icon/default from: grey040: #F2F4F6 => white000: #FFFFFF
Dark theme text/alternative from: grey030: #FAFBFC => grey100: #D6D9DC

## Screenshots

### design tokens storybook
<img width="1440" alt="Screen Shot 2022-04-08 at 11 51 16 AM" src="https://user-images.githubusercontent.com/8112138/162503822-1bfef42e-7e69-4fdd-bbce-9ced04617e8a.png">
<img width="1440" alt="Screen Shot 2022-04-08 at 12 06 33 PM" src="https://user-images.githubusercontent.com/8112138/162508454-0d6c7266-f169-4cc6-acdb-0df81241b924.png">
<img width="1440" alt="Screen Shot 2022-04-08 at 11 51 38 AM" src="https://user-images.githubusercontent.com/8112138/162503827-008220d4-61e0-426f-89e1-ebce393c5496.png">

### Testing in extension
<img width="1038" alt="Screen Shot 2022-04-08 at 12 10 02 PM" src="https://user-images.githubusercontent.com/8112138/162510438-e2bdae2a-a6b8-4ebb-b3f1-53ffcf0b7b3b.png">
<img width="1440" alt="Screen Shot 2022-04-08 at 12 16 31 PM" src="https://user-images.githubusercontent.com/8112138/162510443-d9d4cbfe-4a6e-477c-80f7-982a17a6f94a.png">
<img width="1390" alt="Screen Shot 2022-04-08 at 12 22 52 PM" src="https://user-images.githubusercontent.com/8112138/162510445-dbdbadc5-db50-498a-bfad-27a219d4905c.png">


Fixes: https://github.com/MetaMask/design-tokens/issues/74
Fixes: https://github.com/MetaMask/design-tokens/issues/83