### PR TITLE
updated warning.default to #DA8301

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -175,10 +175,10 @@ const colors: Colors = {
       disabled: '#D73A4980',
     },
     warning: {
-      default: '#FFD33D',
+      default: '#F66A0A',
       alternative: '#FFC70A',
       muted: '#FFD33D19',
-      inverse: '#141618',
+      inverse: '#FCFCFC',
       disabled: '#FFD33D80',
     },
     success: {

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -153,10 +153,10 @@
   --color-error-muted: #d73a4926;
   --color-error-inverse: var(--brand-colors-white-white010);
   --color-error-disabled: #d73a4980;
-  --color-warning-default: var(--brand-colors-yellow-yellow500);
+  --color-warning-default: var(--brand-colors-orange-orange500);
   --color-warning-alternative: var(--brand-colors-yellow-yellow400);
   --color-warning-muted: #ffd33d26;
-  --color-warning-inverse: var(--brand-colors-grey-grey900);
+  --color-warning-inverse: var(--brand-colors-white-white010);
   --color-warning-disabled: #ffd33d80;
   --color-success-default: var(--brand-colors-green-green500);
   --color-success-alternative: var(--brand-colors-green-green400);

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -103,10 +103,10 @@
   --color-error-muted: #d73a4919;
   --color-error-inverse: var(--brand-colors-white-white010);
   --color-error-disabled: #d73a4980;
-  --color-warning-default: var(--brand-colors-yellow-yellow500);
+  --color-warning-default: var(--brand-colors-orange-orange500);
   --color-warning-alternative: var(--brand-colors-yellow-yellow600);
   --color-warning-muted: #ffd33d19;
-  --color-warning-inverse: var(--brand-colors-grey-grey900);
+  --color-warning-inverse: var(--brand-colors-white-white010);
   --color-warning-disabled: #ffd33d80;
   --color-success-default: var(--brand-colors-green-green500);
   --color-success-alternative: var(--brand-colors-green-green500);
@@ -153,10 +153,10 @@
   --color-error-muted: #d73a4926;
   --color-error-inverse: var(--brand-colors-white-white010);
   --color-error-disabled: #d73a4980;
-  --color-warning-default: var(--brand-colors-orange-orange500);
+  --color-warning-default: var(--brand-colors-yellow-yellow500);
   --color-warning-alternative: var(--brand-colors-yellow-yellow400);
   --color-warning-muted: #ffd33d26;
-  --color-warning-inverse: var(--brand-colors-white-white010);
+  --color-warning-inverse: var(--brand-colors-grey-grey900);
   --color-warning-disabled: #ffd33d80;
   --color-success-default: var(--brand-colors-green-green500);
   --color-success-alternative: var(--brand-colors-green-green400);

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -479,8 +479,8 @@
       },
       "warning": {
         "default": {
-          "value": "#FFD33D",
-          "description": "(yellow500: #FFD33D) For low-mid level alert elements. Used for text, background, icon or border",
+          "value": "#F66A0A",
+          "description": "(orange500: #F66A0A) For low-mid level alert elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -494,8 +494,8 @@
           "type": "color"
         },
         "inverse": {
-          "value": "#141618",
-          "description": "(grey900: #141618) For elements used on top of warning/default. Used for text, icon or border",
+          "value": "#FCFCFC",
+          "description": "(white010: #FCFCFC) For elements used on top of warning/default. Used for text, icon or border",
           "type": "color"
         },
         "disabled": {


### PR DESCRIPTION
Closes: https://github.com/MetaMask/design-tokens/issues/92

Updated light theme warning.default from bright yellow to an orange  yellow500 #FFD33D --> orange500 #F66A0A

<img width="1439" alt="Screen Shot 2022-04-26 at 2 20 54 PM" src="https://user-images.githubusercontent.com/8112138/165394849-40f09a92-8dd7-46af-9fbc-6893b5472bf6.png">
<img width="1440" alt="Screen Shot 2022-04-26 at 2 21 25 PM" src="https://user-images.githubusercontent.com/8112138/165394855-25b10363-f985-4fff-ad76-f52dee13e93f.png">
