### PR TITLE
Adding icon alternative

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -10,6 +10,7 @@ export interface ThemeColors {
   };
   icon: {
     default: string;
+    alternative: string;
     muted: string;
   };
   border: {
@@ -143,6 +144,7 @@ const colors: Colors = {
     },
     icon: {
       default: '#24272A',
+      alternative: '#6A737D',
       muted: '#BBC0C5',
     },
     border: {
@@ -209,6 +211,7 @@ const colors: Colors = {
     },
     icon: {
       default: '#FFFFFF',
+      alternative: '#BBC0C5',
       muted: '#9FA6AE',
     },
     border: {

--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -83,6 +83,7 @@ export interface Colors {
  * @property {string} text.muted - Should be used for all low priority text: placeholder and inactive text. It will also not meet AAA or AA accessibility standards
  *
  * @property {string} icon.default - Should be used for all icons used as CTAs that are not a primary action on background.default or background.alternative
+ * @property {string} icon.alternative - For a weaker contrast option for neutral icons
  * @property {string} icon.muted - Should be used for all low priority icon used on background.default or background.alternative. These could also include placeholder or inactive icons. It will also not meet AAA or AA accessibility standards
  *
  * @property {string} border.default - Should be used for for the stroke of components that require higher contrast borders such as inputs in default state

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -82,6 +82,7 @@
   --color-text-alternative: var(--brand-colors-grey-grey600);
   --color-text-muted: var(--brand-colors-grey-grey200);
   --color-icon-default: var(--brand-colors-grey-grey800);
+  --color-icon-alternative: var(--brand-colors-grey-grey500);
   --color-icon-muted: var(--brand-colors-grey-grey200);
   --color-border-default: var(--brand-colors-grey-grey200);
   --color-border-muted: var(--brand-colors-grey-grey100);
@@ -132,6 +133,7 @@
   --color-text-alternative: var(--brand-colors-grey-grey100);
   --color-text-muted: var(--brand-colors-grey-grey400);
   --color-icon-default: var(--brand-colors-white-white000);
+  --color-icon-alternative: var(--brand-colors-grey-grey200);
   --color-icon-muted: var(--brand-colors-grey-grey400);
   --color-border-default: var(--brand-colors-grey-grey400);
   --color-border-muted: var(--brand-colors-grey-grey700);

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -361,6 +361,11 @@
           "description": "(grey800: #24272A) For default neutral icons",
           "type": "color"
         },
+        "alternative": {
+          "value": "#6A737D",
+          "type": "color",
+          "description": "(grey500: #6A737D) For a weaker contrast option for neutral icons."
+        },
         "muted": {
           "value": "#BBC0C5",
           "description": "(grey200: #BBC0C5) For inactive or lowest priority icons",
@@ -596,6 +601,11 @@
           "value": "#FFFFFF",
           "description": "(white000: #FFFFFF) For default neutral icons",
           "type": "color"
+        },
+        "alternative": {
+          "value": "#F2F4F6",
+          "type": "color",
+          "description": "(grey040: #F2F4F6) For a weaker contrast option for neutral icons."
         },
         "muted": {
           "value": "#9FA6AE",

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -603,9 +603,9 @@
           "type": "color"
         },
         "alternative": {
-          "value": "#F2F4F6",
+          "value": "#BBC0C5",
           "type": "color",
-          "description": "(grey040: #F2F4F6) For a weaker contrast option for neutral icons."
+          "description": "(grey200: #BBC0C5) For a weaker contrast option for neutral icons."
         },
         "muted": {
           "value": "#9FA6AE",

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -364,7 +364,7 @@
         "alternative": {
           "value": "#6A737D",
           "type": "color",
-          "description": "(grey500: #6A737D) For a weaker contrast option for neutral icons."
+          "description": "(grey500: #6A737D) For a weaker contrast option for neutral icons"
         },
         "muted": {
           "value": "#BBC0C5",
@@ -605,7 +605,7 @@
         "alternative": {
           "value": "#BBC0C5",
           "type": "color",
-          "description": "(grey200: #BBC0C5) For a weaker contrast option for neutral icons."
+          "description": "(grey200: #BBC0C5) For a weaker contrast option for neutral icons"
         },
         "muted": {
           "value": "#9FA6AE",


### PR DESCRIPTION
- Added new token icon/alternative for light theme with value of (grey500: #6A737D) and description
- Added new token icon/alternative for dark theme with value of (grey200: #BBC0C5) and description

<img width="1440" alt="Screen Shot 2022-04-26 at 2 46 36 PM" src="https://user-images.githubusercontent.com/8112138/165399045-a5ce04c3-bb3b-47f3-a0d3-eda1c1d260cf.png">
<img width="1440" alt="Screen Shot 2022-04-26 at 2 56 37 PM" src="https://user-images.githubusercontent.com/8112138/165399152-483d0025-4ef1-4722-aca6-731f2f41d4a4.png">
