### PR TITLE
Storybook github actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,3 +27,15 @@ jobs:
       - uses: MetaMask/action-publish-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: MetaMask/action-publish-gh-pages@v2
+        with:
+          build-command: build-storybook
+          source-directory: storybook-static
+          # This will commit the contents of "public" in the source branch to
+          # a directory named "latest" on the gh-pages branch.
+          # If destination-directory were omitted, all existing content of the
+          # gh-pages branch would be deleted and the the contents of "public"
+          # would be committed to the root directory.
+          destination-directory: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Creating github action that publishes storybook to github pages on every merge to `main` branch. Use the metamask/action-publish-gh-pages repo https://github.com/MetaMask/action-publish-gh-pages

- Updating storybook version