### PR TITLE
Updating typography tests and some token json

### DIFF
--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -662,7 +662,7 @@
         "fontWeight": "$fontWeights.euclid-circular-b-1",
         "lineHeight": "$lineHeights.5",
         "fontSize": "$fontSize.1",
-        "letterSpacing": "$letterSpacing.1",
+        "letterSpacing": "$letterSpacing.0",
         "paragraphSpacing": "$paragraphSpacing.0",
         "textCase": "$textCase.none",
         "textDecoration": "$textDecoration.none"
@@ -675,7 +675,7 @@
         "fontWeight": "$fontWeights.euclid-circular-b-2",
         "lineHeight": "$lineHeights.5",
         "fontSize": "$fontSize.1",
-        "letterSpacing": "$letterSpacing.1",
+        "letterSpacing": "$letterSpacing.0",
         "paragraphSpacing": "$paragraphSpacing.0",
         "textCase": "$textCase.none",
         "textDecoration": "$textDecoration.none"

--- a/src/js/typography/typography.test.ts
+++ b/src/js/typography/typography.test.ts
@@ -4,12 +4,12 @@ import { typography } from './typography';
 const designTokens = require('../../figma/tokens.json');
 
 /**
- * Trim string between 2 characters
+ * Trim string between 2 characters.
  *
- * @param {string} str - The string to be trimmed
- * @param {string} firstChar - The first character to start from '$'
- * @param {string} lastChar - The last character to stop at '.'
- * @returns {string}
+ * @param str - The string to be trimmed.
+ * @param firstChar - The first character to start from '$'.
+ * @param lastChar - The last character to stop at '.'.
+ * @returns A string from characters between firstChar and lastChar.
  */
 function trimStringBetweenCharacters(
   str: string,
@@ -20,22 +20,22 @@ function trimStringBetweenCharacters(
 }
 
 /**
- * Trim string after character. Default character is '.'
+ * Trim string after character. Default character is '.'.
  *
- * @param {string} str - The string to be trimmed
- * @param {string} char - The first character to start from '.'
- * @returns {string}
+ * @param str - The string to be trimmed.
+ * @param char - The first character to start from '.'.
+ * @returns A string from characters after the `char`.
  */
 function trimStringAfterCharacter(str: string, char = '.') {
   return str.split(char).pop();
 }
 
 /**
- * Creates a new figma token object by creating object keys from a string
+ * Creates a new figma token object by creating object keys from a string.
  *
- * @param {string} str - The object path as a string to be trimmed into object keys
- * @param {Object} obj - Global figma token object
- * @returns {Object} - New object formed from object keys created from provided string
+ * @param str - The object path as a string to be trimmed into object keys.
+ * @param obj - Global figma token object.
+ * @returns New object formed from object keys created from provided string.
  */
 function createNewFigmaTokenObject(str: string, obj: any) {
   const firstString = trimStringBetweenCharacters(str);

--- a/src/js/typography/typography.test.ts
+++ b/src/js/typography/typography.test.ts
@@ -3,366 +3,788 @@ import { typography } from './typography';
 
 const designTokens = require('../../figma/tokens.json');
 
-describe('Typography Small Screen', () => {
-  it('js tokens for sDisplayMD matches figma tokens sDisplayMD', () => {
-    expect(typography.sDisplayMD.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sDisplayMD.fontWeight).toStrictEqual('700');
-    expect(typography.sDisplayMD.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[6].value,
-    );
+/**
+ * Trim string between 2 characters
+ *
+ * @param {string} str - The string to be trimmed
+ * @param {string} firstChar - The first character to start from '$'
+ * @param {string} lastChar - The last character to stop at '.'
+ * @returns {string}
+ */
+function trimStringBetweenCharacters(
+  str: string,
+  firstChar = '$',
+  lastChar = '.',
+) {
+  return str.substring(str.indexOf(firstChar) + 1, str.lastIndexOf(lastChar));
+}
 
-    expect(typography.sDisplayMD.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[1].value,
-    );
+/**
+ * Trim string after character. Default character is '.'
+ *
+ * @param {string} str - The string to be trimmed
+ * @param {string} char - The first character to start from '.'
+ * @returns {string}
+ */
+function trimStringAfterCharacter(str: string, char = '.') {
+  return str.split(char).pop();
+}
 
-    expect(typography.sDisplayMD.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
+/**
+ * Creates a new figma token object by creating object keys from a string
+ *
+ * @param {string} str - The object path as a string to be trimmed into object keys
+ * @param {Object} obj - Global figma token object
+ * @returns {Object} - New object formed from object keys created from provided string
+ */
+function createNewFigmaTokenObject(str: string, obj: any) {
+  const firstString = trimStringBetweenCharacters(str);
+  const secondString = trimStringAfterCharacter(str);
+  return obj[`${firstString}`][`${secondString}`];
+}
+
+describe('Typography', () => {
+  describe('Typography Small Screen', () => {
+    it('js tokens for sDisplayMD matches figma tokens sDisplayMD', () => {
+      expect(typography.sDisplayMD.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Display-MD'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sDisplayMD.fontWeight).toStrictEqual('700');
+
+      expect(typography.sDisplayMD.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Display-MD'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sDisplayMD.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Display-MD'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sDisplayMD.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Display-MD'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sHeadingLG matches figma tokens sHeadingLG', () => {
+      expect(typography.sHeadingLG.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Heading-LG'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sHeadingLG.fontWeight).toStrictEqual('700');
+
+      expect(typography.sHeadingLG.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-LG'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingLG.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-LG'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingLG.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-LG'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sHeadingMD matches figma tokens sHeadingMD', () => {
+      expect(typography.sHeadingMD.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Heading-MD'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sHeadingMD.fontWeight).toStrictEqual('700');
+
+      expect(typography.sHeadingMD.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-MD'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingMD.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-MD'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingMD.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-MD'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sHeadingSMRegular matches figma tokens sHeadingSMRegular', () => {
+      expect(typography.sHeadingSMRegular.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Heading-SM-Regular'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sHeadingSMRegular.fontWeight).toStrictEqual('400');
+
+      expect(typography.sHeadingSMRegular.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-SM-Regular'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingSMRegular.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-SM-Regular'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingSMRegular.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-SM-Regular'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sHeadingSM matches figma tokens sHeadingSM', () => {
+      expect(typography.sHeadingSM.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Heading-SM'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sHeadingSM.fontWeight).toStrictEqual('700');
+
+      expect(typography.sHeadingSM.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-SM'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingSM.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-SM'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sHeadingSM.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Heading-SM'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sBodyMDBold matches figma tokens sBodyMDBold', () => {
+      expect(typography.sBodyMDBold.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Body-MD-Bold'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sBodyMDBold.fontWeight).toStrictEqual('700');
+
+      expect(typography.sBodyMDBold.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-MD-Bold'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodyMDBold.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-MD-Bold'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodyMDBold.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-MD-Bold'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sBodyMD matches figma tokens sBodyMD', () => {
+      expect(typography.sBodyMD.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Body-MD'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sBodyMD.fontWeight).toStrictEqual('400');
+
+      expect(typography.sBodyMD.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-MD'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodyMD.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-MD'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodyMD.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-MD'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sBodySMBold matches figma tokens sBodySMBold', () => {
+      expect(typography.sBodySMBold.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Body-SM-Bold'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sBodySMBold.fontWeight).toStrictEqual('700');
+
+      expect(typography.sBodySMBold.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-SM-Bold'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodySMBold.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-SM-Bold'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodySMBold.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-SM-Bold'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sBodySM matches figma tokens sBodySM', () => {
+      expect(typography.sBodySM.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Body-SM'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sBodySM.fontWeight).toStrictEqual('400');
+
+      expect(typography.sBodySM.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-SM'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodySM.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-SM'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodySM.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-SM'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
+
+    it('js tokens for sBodyXS matches figma tokens sBodyXS', () => {
+      expect(typography.sBodyXS.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['S-Body-XS'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.sBodyXS.fontWeight).toStrictEqual('400');
+
+      expect(typography.sBodyXS.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-XS'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodyXS.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-XS'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
+
+      expect(typography.sBodyXS.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['S-Body-XS'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
   });
 
-  it('js tokens for sHeadingLG matches figma tokens sHeadingLG', () => {
-    expect(typography.sHeadingLG.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sHeadingLG.fontWeight).toStrictEqual('700');
-    expect(typography.sHeadingLG.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[5].value,
-    );
+  describe('Typography Large Screen', () => {
+    it('js tokens for lDisplayMD matches figma tokens lDisplayMD', () => {
+      expect(typography.lDisplayMD.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Display-MD'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lDisplayMD.fontWeight).toStrictEqual('500');
 
-    expect(typography.sHeadingLG.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[2].value,
-    );
+      expect(typography.lDisplayMD.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Display-MD'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sHeadingLG.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lDisplayMD.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Display-MD'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-  it('js tokens for sHeadingMD matches figma tokens sHeadingMD', () => {
-    expect(typography.sHeadingMD.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sHeadingMD.fontWeight).toStrictEqual('700');
-    expect(typography.sHeadingMD.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[4].value,
-    );
+      expect(typography.lDisplayMD.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Display-MD'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-    expect(typography.sHeadingMD.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
+    it('js tokens for lHeadingLG matches figma tokens lHeadingLG', () => {
+      expect(typography.lHeadingLG.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Heading-LG'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lHeadingLG.fontWeight).toStrictEqual('700');
 
-    expect(typography.sHeadingMD.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lHeadingLG.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-LG'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-  it('js tokens for sHeadingSMRegular matches figma tokens sHeadingSMRegular', () => {
-    expect(typography.sHeadingSMRegular.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sHeadingSMRegular.fontWeight).toStrictEqual('400');
-    expect(typography.sHeadingSMRegular.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[3].value,
-    );
+      expect(typography.lHeadingLG.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-LG'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sHeadingSMRegular.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
+      expect(typography.lHeadingLG.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-LG'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-    expect(typography.sHeadingSMRegular.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+    it('js tokens for lHeadingMD matches figma tokens lHeadingMD', () => {
+      expect(typography.lHeadingMD.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Heading-MD'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lHeadingMD.fontWeight).toStrictEqual('700');
 
-  it('js tokens for sHeadingSM matches figma tokens sHeadingSM', () => {
-    expect(typography.sHeadingSM.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sHeadingSM.fontWeight).toStrictEqual('700');
-    expect(typography.sHeadingSM.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[3].value,
-    );
+      expect(typography.lHeadingMD.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-MD'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sHeadingSM.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
+      expect(typography.lHeadingMD.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-MD'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sHeadingSM.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lHeadingMD.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-MD'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-  it('js tokens for sBodyMDBold matches figma tokens sBodyMDBold', () => {
-    expect(typography.sBodyMDBold.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sBodyMDBold.fontWeight).toStrictEqual('700');
-    expect(typography.sBodyMDBold.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[2].value,
-    );
+    it('js tokens for lHeadingSMRegular matches figma tokens lHeadingSMRegular', () => {
+      expect(typography.lHeadingSMRegular.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Heading-SM-Regular'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lHeadingSMRegular.fontWeight).toStrictEqual('400');
 
-    expect(typography.sBodyMDBold.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[4].value,
-    );
+      expect(typography.lHeadingSMRegular.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-SM-Regular'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sBodyMDBold.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lHeadingSMRegular.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-SM-Regular'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-  it('js tokens for sBodyMD matches figma tokens sBodyMD', () => {
-    expect(typography.sBodyMD.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sBodyMD.fontWeight).toStrictEqual('400');
-    expect(typography.sBodyMD.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[2].value,
-    );
+      expect(typography.lHeadingSMRegular.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-SM-Regular'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-    expect(typography.sBodyMD.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[4].value,
-    );
+    it('js tokens for lHeadingSM matches figma tokens lHeadingSM', () => {
+      expect(typography.lHeadingSM.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Heading-SM'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lHeadingSM.fontWeight).toStrictEqual('700');
 
-    expect(typography.sBodyMD.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lHeadingSM.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-SM'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-  it('js tokens for sBodySMBold matches figma tokens sBodySMBold', () => {
-    expect(typography.sBodySMBold.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sBodySMBold.fontWeight).toStrictEqual('700');
-    expect(typography.sBodySMBold.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[1].value,
-    );
+      expect(typography.lHeadingSM.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-SM'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sBodySMBold.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[5].value,
-    );
+      expect(typography.lHeadingSM.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Heading-SM'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-    expect(typography.sBodySMBold.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+    it('js tokens for lBodyMDBold matches figma tokens lBodyMDBold', () => {
+      expect(typography.lBodyMDBold.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Body-MD-Bold'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lBodyMDBold.fontWeight).toStrictEqual('700');
 
-  it('js tokens for sBodySM matches figma tokens sBodySM', () => {
-    expect(typography.sBodySM.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sBodySM.fontWeight).toStrictEqual('400');
-    expect(typography.sBodySM.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[1].value,
-    );
+      expect(typography.lBodyMDBold.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-MD-Bold'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sBodySM.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[5].value,
-    );
+      expect(typography.lBodyMDBold.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-MD-Bold'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sBodySM.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lBodyMDBold.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-MD-Bold'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-  it('js tokens for sBodyXS matches figma tokens sBodyXS', () => {
-    expect(typography.sBodyXS.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.sBodyXS.fontWeight).toStrictEqual('400');
-    expect(typography.sBodyXS.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[0].value,
-    );
+    it('js tokens for lBodyMD matches figma tokens lBodyMD', () => {
+      expect(typography.lBodyMD.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Body-MD'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lBodyMD.fontWeight).toStrictEqual('400');
 
-    expect(typography.sBodyXS.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[6].value,
-    );
+      expect(typography.lBodyMD.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-MD'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.sBodyXS.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[1].value,
-    );
-  });
-});
+      expect(typography.lBodyMD.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-MD'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-describe('Typography Large Screen', () => {
-  it('js tokens for lDisplayMD matches figma tokens lDisplayMD', () => {
-    expect(typography.lDisplayMD.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lDisplayMD.fontWeight).toStrictEqual('500');
-    expect(typography.lDisplayMD.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[7].value,
-    );
+      expect(typography.lBodyMD.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-MD'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-    expect(typography.lDisplayMD.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[0].value,
-    );
+    it('js tokens for lBodySMBold matches figma tokens lBodySMBold', () => {
+      expect(typography.lBodySMBold.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Body-SM-Bold'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lBodySMBold.fontWeight).toStrictEqual('700');
 
-    expect(typography.lDisplayMD.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lBodySMBold.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-SM-Bold'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-  it('js tokens for lHeadingLG matches figma tokens lHeadingLG', () => {
-    expect(typography.lHeadingLG.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lHeadingLG.fontWeight).toStrictEqual('700');
-    expect(typography.lHeadingLG.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[6].value,
-    );
+      expect(typography.lBodySMBold.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-SM-Bold'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.lHeadingLG.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[1].value,
-    );
+      expect(typography.lBodySMBold.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-SM-Bold'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-    expect(typography.lHeadingLG.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+    it('js tokens for lBodySM matches figma tokens lBodySM', () => {
+      expect(typography.lBodySM.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Body-SM'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lBodySM.fontWeight).toStrictEqual('400');
 
-  it('js tokens for lHeadingMD matches figma tokens lHeadingMD', () => {
-    expect(typography.lHeadingMD.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lHeadingMD.fontWeight).toStrictEqual('700');
-    expect(typography.lHeadingMD.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[5].value,
-    );
+      expect(typography.lBodySM.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-SM'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.lHeadingMD.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[2].value,
-    );
+      expect(typography.lBodySM.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-SM'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.lHeadingMD.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lBodySM.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-SM'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
 
-  it('js tokens for lHeadingSMRegular matches figma tokens lHeadingSMRegular', () => {
-    expect(typography.lHeadingSMRegular.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lHeadingSMRegular.fontWeight).toStrictEqual('400');
-    expect(typography.lHeadingSMRegular.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[4].value,
-    );
+    it('js tokens for lBodyXS matches figma tokens lBodyXS', () => {
+      expect(typography.lBodyXS.fontFamily).toStrictEqual(
+        createNewFigmaTokenObject(
+          designTokens.global['L-Body-XS'].value.fontFamily,
+          designTokens.global,
+        ).value,
+      );
+      expect(typography.lBodyXS.fontWeight).toStrictEqual('400');
 
-    expect(typography.lHeadingSMRegular.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
+      expect(typography.lBodyXS.fontSize).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-XS'].value.fontSize,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-    expect(typography.lHeadingSMRegular.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
+      expect(typography.lBodyXS.lineHeight).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-XS'].value.lineHeight,
+            designTokens.global,
+          ).value,
+        ),
+      );
 
-  it('js tokens for lHeadingSM matches figma tokens lHeadingSM', () => {
-    expect(typography.lHeadingSM.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lHeadingSM.fontWeight).toStrictEqual('700');
-    expect(typography.lHeadingSM.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[4].value,
-    );
-
-    expect(typography.lHeadingSM.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
-
-    expect(typography.lHeadingSM.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
-
-  it('js tokens for lBodyMDBold matches figma tokens lBodyMDBold', () => {
-    expect(typography.lBodyMDBold.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lBodyMDBold.fontWeight).toStrictEqual('700');
-    expect(typography.lBodyMDBold.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[3].value,
-    );
-
-    expect(typography.lBodyMDBold.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
-
-    expect(typography.lBodyMDBold.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
-
-  it('js tokens for lBodyMD matches figma tokens lBodyMD', () => {
-    expect(typography.lBodyMD.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lBodyMD.fontWeight).toStrictEqual('400');
-    expect(typography.lBodyMD.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[3].value,
-    );
-
-    expect(typography.lBodyMD.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[3].value,
-    );
-
-    expect(typography.lBodyMD.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
-
-  it('js tokens for lBodySMBold matches figma tokens lBodySMBold', () => {
-    expect(typography.lBodySMBold.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lBodySMBold.fontWeight).toStrictEqual('700');
-    expect(typography.lBodySMBold.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[2].value,
-    );
-
-    expect(typography.lBodySMBold.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[4].value,
-    );
-
-    expect(typography.lBodySMBold.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
-
-  it('js tokens for lBodySM matches figma tokens lBodySM', () => {
-    expect(typography.lBodySM.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lBodySM.fontWeight).toStrictEqual('400');
-    expect(typography.lBodySM.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[2].value,
-    );
-
-    expect(typography.lBodySM.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[4].value,
-    );
-
-    expect(typography.lBodySM.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[0].value,
-    );
-  });
-
-  it('js tokens for lBodyXS matches figma tokens lBodyXS', () => {
-    expect(typography.lBodyXS.fontFamily).toStrictEqual(
-      designTokens.global.fontFamilies['euclid-circular-b'].value,
-    );
-    expect(typography.lBodyXS.fontWeight).toStrictEqual('400');
-    expect(typography.lBodyXS.fontSize.toString()).toStrictEqual(
-      designTokens.global.fontSize[1].value,
-    );
-
-    expect(typography.lBodyXS.lineHeight.toString()).toStrictEqual(
-      designTokens.global.lineHeights[5].value,
-    );
-
-    expect(typography.lBodyXS.letterSpacing.toString()).toStrictEqual(
-      designTokens.global.letterSpacing[1].value,
-    );
+      expect(typography.lBodyXS.letterSpacing).toStrictEqual(
+        Number(
+          createNewFigmaTokenObject(
+            designTokens.global['L-Body-XS'].value.letterSpacing,
+            designTokens.global,
+          ).value,
+        ),
+      );
+    });
   });
 });


### PR DESCRIPTION
### Description

PR https://github.com/MetaMask/design-tokens/pull/144 made it evident that we do not have sufficient testing for the typography objects in the figma token json.

This PR updates tests to check against the typography style objects from the figma json rather than just checking the individual tokens(fontSize, fontFamily, letterSpacing, etc) that make up the typography styles.

It also includes one update to the letter spacing tokens for `S-Body-SM-Bold` and `S-Body-SM`

Fixes: #146