### PR TITLE
Updating readme with npm and storybook badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaMask Design Tokens 🪙
 
-[![npm version](https://badge.fury.io/js/survey-monkey-streams.svg)](//npmjs.com/package/@metamask/design-tokens) [![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
+[![npm version](https://badge.fury.io/js/survey-monkey-streams.svg)](https://npmjs.com/package/@metamask/design-tokens) [![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
 
 ## `@metamask/design-tokens`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MetaMask Design Tokens 🪙
 
+[![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
+
 ## `@metamask/design-tokens`
 
 A collection of design tokens based on MetaMask's design system.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaMask Design Tokens 🪙
 
-[![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
+[![npm version](https://badge.fury.io/js/survey-monkey-streams.svg)](//npmjs.com/package/@metamask/design-tokens) [![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
 
 ## `@metamask/design-tokens`
 


### PR DESCRIPTION
### Description
Adding npm package version and storybook badges to readme for quick discovery of published package version number and storybook github page


## Screenshots

<img width="1234" alt="Screen Shot 2022-05-20 at 2 48 50 PM" src="https://user-images.githubusercontent.com/8112138/169617054-5ffc3d30-10eb-4f9a-9bf9-dfb9ac981747.png">


### Testing criteria 
- npm badge should go to npm package
- storybook badge should go to storybook github page