### PR TITLE
Fix for readme badge to show correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaMask Design Tokens 🪙
 
-[![npm version](https://badge.fury.io/js/survey-monkey-streams.svg)](https://npmjs.com/package/@metamask/design-tokens) [![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
+[![npm version](https://badge.fury.io/js/@metamask%2Fdesign-tokens.svg)](https://npmjs.com/package/@metamask/design-tokens) [![Storybook](https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg)](https://metamask.github.io/design-tokens)
 
 ## `@metamask/design-tokens`
 


### PR DESCRIPTION
### Description
NPM badge is not showing incorrect version in readme. This fixes that.

## Before
<img width="880" alt="Screen Shot 2022-06-06 at 2 18 01 PM" src="https://user-images.githubusercontent.com/8112138/172250969-d65bc523-1e41-479c-b4bb-802bde6c6a89.png">

## After 
![Screen Shot 2022-06-06 at 2 18 14 PM](https://user-images.githubusercontent.com/8112138/172250991-3721ba97-096e-40f0-bda1-8247497f82ba.png)
