### PR TITLE
Hover and Pressed tokens for Dark Theme

### DIFF
--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -1049,6 +1049,22 @@
           "value": "#141618",
           "description": "(grey900: #141618) For a subtle contrast option for neutral backgrounds. (Example: backdrop, header background)",
           "type": "color"
+        },
+        "default-hover": {
+          "value": "#3b4046",
+          "type": "color"
+        },
+        "default-pressed": {
+          "value": "#3b4046",
+          "type": "color"
+        },
+        "alternative-hover": {
+          "value": "#2e3339",
+          "type": "color"
+        },
+        "alternative-pressed": {
+          "value": "#2e3339",
+          "type": "color"
         }
       },
       "text": {
@@ -1346,5 +1362,12 @@
       }
     }
   },
-  "$themes": []
+  "$themes": [],
+  "$metadata": {
+    "tokenSetOrder": [
+      "global",
+      "light",
+      "dark"
+    ]
+  }
 }


### PR DESCRIPTION
Added new `background/default-hover`,` background/default-pressed`, `background/alternative-hover` and `background/alternative-pressed` tokens for Dark Theme.

<img width="459" alt="Screenshot 2022-08-26 at 18 55 53" src="https://user-images.githubusercontent.com/98161559/186954968-93ca9dd2-e64c-4a42-aa5e-baea3244f1e9.png">

