### PR TITLE
Updated default.hover & default.pressed from grey030 to grey040

### DIFF
--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -750,14 +750,14 @@
           "type": "color"
         },
         "default-hover": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) (grey030: #FAFBFC) For component hover states that use background/default",
-          "type": "color"
+          "value": "#F2F4F6",
+          "type": "color",
+          "description": "(grey040: #F2F4F6) For component hover states that use background/default"
         },
         "default-pressed": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) For component pressed states that use background/default",
-          "type": "color"
+          "value": "#F2F4F6",
+          "type": "color",
+          "description": "(grey040: #F2F4F6) For component pressed states that use background/default"
         },
         "alternative": {
           "value": "#F2F4F6",
@@ -1507,6 +1507,10 @@
   },
   "$themes": [],
   "$metadata": {
-    "tokenSetOrder": ["global", "light", "dark"]
+    "tokenSetOrder": [
+      "global",
+      "light",
+      "dark"
+    ]
   }
 }


### PR DESCRIPTION
Updated Light-theme color tokens.
`default.hover` :  `grey030` --> `grey040`
`default.pressed`:  `grey030` --> `grey040`

Reason for update : grey030 is too light.
GIF shows in grey040 which has more contrast

### Screenshots
## Before

(Add before)


## After

![Nov-17-2022 13-48-55](https://user-images.githubusercontent.com/55973039/202567316-98426d2d-0611-4f3e-91b0-ab82b47d6c05.gif)

