### PR TITLE
Updating colors Blue500 & Red400 with added contrast for accessibility

### DIFF
--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -109,9 +109,9 @@
           "type": "color"
         },
         "blue500": {
-          "value": "#037DD6",
-          "description": "(HEX: #037DD6)",
-          "type": "color"
+          "value": "#0376C9",
+          "type": "color",
+          "description": "(HEX: #0376C9)"
         },
         "blue600": {
           "value": "#0260A4",
@@ -260,9 +260,9 @@
           "type": "color"
         },
         "red400": {
-          "value": "#E06470",
-          "description": "(HEX: #E06470)",
-          "type": "color"
+          "value": "#E26F7A",
+          "type": "color",
+          "description": "(HEX: #E26F7A)"
         },
         "red500": {
           "value": "#D73A49",
@@ -1507,6 +1507,10 @@
   },
   "$themes": [],
   "$metadata": {
-    "tokenSetOrder": ["global", "light", "dark"]
+    "tokenSetOrder": [
+      "global",
+      "light",
+      "dark"
+    ]
   }
 }

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -109,9 +109,9 @@
           "type": "color"
         },
         "blue500": {
-          "value": "#0376C9",
-          "type": "color",
-          "description": "(HEX: #0376C9)"
+          "value": "#037DD6",
+          "description": "(HEX: #037DD6)",
+          "type": "color"
         },
         "blue600": {
           "value": "#0260A4",
@@ -260,9 +260,9 @@
           "type": "color"
         },
         "red400": {
-          "value": "#E26F7A",
-          "type": "color",
-          "description": "(HEX: #E26F7A)"
+          "value": "#E06470",
+          "description": "(HEX: #E06470)",
+          "type": "color"
         },
         "red500": {
           "value": "#D73A49",
@@ -1279,19 +1279,19 @@
       },
       "error": {
         "default": {
-          "value": "#D73A49",
-          "description": "(red500: #D73A49) For high-level alert danger/critical elements. Used for text, background, icon or border",
-          "type": "color"
+          "value": "#E26F7A",
+          "type": "color",
+          "description": "(red400: #E26F7A) For high-level alert danger/critical elements. Used for text, background, icon or border"
         },
         "alternative": {
-          "value": "#E06470",
-          "description": "(red400: #E06470) For the \"pressed\" state of interactive danger/critical elements",
-          "type": "color"
+          "value": "#E88F97",
+          "type": "color",
+          "description": "(red300: #E88F97) For the \"pressed\" state of interactive danger/critical elements"
         },
         "muted": {
-          "value": "#D73A4926",
-          "description": "(red500: #D73A49 15% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
-          "type": "color"
+          "value": "#E26F7A26",
+          "type": "color",
+          "description": "(red400: #E26F7A 15% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)"
         },
         "inverse": {
           "value": "#FCFCFC",


### PR DESCRIPTION
Updating the value of two color tokens.

Blue500 : #037DD6 --> #0376C9
Red400 : #E06470 --> #E26F7A

Why update Blue500?
Blue500 (#037DD6)  is a common color used for text but misses the AA contrast ratio requirement of 4.5 against light theme default.background. The proposed new color #0376C9 fulfills this contrast requirement.
<img width="321" alt="image" src="https://user-images.githubusercontent.com/55973039/203186287-8dab38c1-63d4-4bfe-b3e0-259cf9ea0a3a.png">
<img width="323" alt="image" src="https://user-images.githubusercontent.com/55973039/203186388-5137fde2-8d30-4755-a571-14bc7bcce3ab.png">


Why update Red400?
Red400(#E06470) is slightly off the desired AA contrast ratio 4.5 against dark theme default.background.The proposed new color  #E26F7A will fulfill this cotrast requirement.
<img width="325" alt="image" src="https://user-images.githubusercontent.com/55973039/203186338-c61f5772-8431-4a12-a4b1-8195a694df57.png">
<img width="323" alt="image" src="https://user-images.githubusercontent.com/55973039/203186357-97bc18c1-ee8d-4e8e-97f6-2f39b4601c68.png">
