### PR TITLE
Updating primary, error and info colors to meet AA accessibility standards for light mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "workbench.colorCustomizations": {
-    "titleBar.activeBackground": "#037DD6",
+    "titleBar.activeBackground": "#0376C9",
     "titleBar.activeForeground": "#ffffff"
   }
 }

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -26,7 +26,7 @@
   --brand-colors-blue-blue200: #75c4fd;
   --brand-colors-blue-blue300: #43aefc;
   --brand-colors-blue-blue400: #1098fc;
-  --brand-colors-blue-blue500: #037dd6;
+  --brand-colors-blue-blue500: #0376c9;
   --brand-colors-blue-blue600: #0260a4;
   --brand-colors-blue-blue700: #024272;
   --brand-colors-blue-blue800: #01253f;
@@ -262,10 +262,10 @@
   --color-shadow-default: #0000001a;
   --color-primary-default: var(--brand-colors-blue-blue500);
   --color-primary-alternative: var(--brand-colors-blue-blue600);
-  --color-primary-muted: #037dd619;
+  --color-primary-muted: #0376c919;
   --color-primary-inverse: var(--brand-colors-white-white010);
-  --color-primary-disabled: #037dd680;
-  --color-primary-shadow: #037dd633;
+  --color-primary-disabled: #0376c980;
+  --color-primary-shadow: #0376c933;
   --color-secondary-default: var(--brand-colors-orange-orange500);
   --color-secondary-alternative: var(--brand-colors-orange-orange600);
   --color-secondary-muted: #f66a0a19;
@@ -289,9 +289,9 @@
   --color-success-disabled: #28a74580;
   --color-info-default: var(--brand-colors-blue-blue500);
   --color-info-alternative: var(--brand-colors-blue-blue600);
-  --color-info-muted: #037dd619;
+  --color-info-muted: #0376c919;
   --color-info-inverse: var(--brand-colors-white-white010);
-  --color-info-disabled: #037dd680;
+  --color-info-disabled: #0376c980;
   --color-network-goerli-default: var(--brand-colors-blue-blue400);
   --color-network-goerli-inverse: var(--brand-colors-white-white010);
   --color-network-localhost-default: var(--brand-colors-grey-grey200);
@@ -338,7 +338,7 @@
   --color-primary-muted: #1098fc26;
   --color-primary-inverse: var(--brand-colors-white-white010);
   --color-primary-disabled: #1098fc80;
-  --color-primary-shadow: #037dd633;
+  --color-primary-shadow: #0376c933;
   --color-secondary-default: var(--brand-colors-orange-orange400);
   --color-secondary-alternative: var(--brand-colors-orange-orange300);
   --color-secondary-muted: #f8883b26;
@@ -364,5 +364,5 @@
   --color-info-alternative: var(--brand-colors-blue-blue300);
   --color-info-muted: #1098fc26;
   --color-info-inverse: var(--brand-colors-white-white010);
-  --color-info-disabled: #037dd680;
+  --color-info-disabled: #0376c980;
 }

--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -56,7 +56,7 @@
   --brand-colors-red-red200: #f1b9be;
   --brand-colors-red-red300: #e88f97;
   --brand-colors-red-red400: #e06470;
-  --brand-colors-red-red500: #d73a49;
+  --brand-colors-red-red500: #d73847;
   --brand-colors-red-red600: #b92534;
   --brand-colors-red-red700: #8e1d28;
   --brand-colors-red-red800: #64141c;
@@ -273,10 +273,10 @@
   --color-secondary-disabled: #f66a0a80;
   --color-error-default: var(--brand-colors-red-red500);
   --color-error-alternative: var(--brand-colors-red-red600);
-  --color-error-muted: #d73a4919;
+  --color-error-muted: #d7384719;
   --color-error-inverse: var(--brand-colors-white-white010);
-  --color-error-disabled: #d73a4980;
-  --color-error-shadow: #d73a4966;
+  --color-error-disabled: #d7384780;
+  --color-error-shadow: #d7384766;
   --color-warning-default: var(--brand-colors-orange-orange500);
   --color-warning-alternative: var(--brand-colors-yellow-yellow600);
   --color-warning-muted: #ffd33d19;
@@ -346,10 +346,10 @@
   --color-secondary-disabled: #f8883b80;
   --color-error-default: var(--brand-colors-red-red500);
   --color-error-alternative: var(--brand-colors-red-red400);
-  --color-error-muted: #d73a4926;
+  --color-error-muted: #d7384726;
   --color-error-inverse: var(--brand-colors-white-white010);
-  --color-error-disabled: #d73a4980;
-  --color-error-shadow: #d73a4966;
+  --color-error-disabled: #d7384780;
+  --color-error-shadow: #d7384766;
   --color-warning-default: var(--brand-colors-yellow-yellow500);
   --color-warning-alternative: var(--brand-colors-yellow-yellow400);
   --color-warning-muted: #ffd33d26;

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -109,8 +109,8 @@
           "type": "color"
         },
         "blue500": {
-          "value": "#037DD6",
-          "description": "(HEX: #037DD6)",
+          "value": "#0376C9",
+          "description": "(HEX: #0376C9)",
           "type": "color"
         },
         "blue600": {
@@ -840,8 +840,8 @@
       },
       "primary": {
         "default": {
-          "value": "#037DD6",
-          "description": "(blue500: #037DD6) For primary user action related elements",
+          "value": "#0376C9",
+          "description": "(blue500: #0376C9) For primary user action related elements",
           "type": "color"
         },
         "alternative": {
@@ -850,8 +850,8 @@
           "type": "color"
         },
         "muted": {
-          "value": "#037DD619",
-          "description": "(blue500: #037DD6 10% opacity) For lowest contrast background used in primary elements",
+          "value": "#0376C919",
+          "description": "(blue500: #0376C9 10% opacity) For lowest contrast background used in primary elements",
           "type": "color"
         },
         "inverse": {
@@ -860,8 +860,8 @@
           "type": "color"
         },
         "disabled": {
-          "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) [DEPRECATED] primary.disabled should be used for all disabled primary action components such as buttons or links",
+          "value": "#0376C980",
+          "description": "(blue500: #0376C9 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       },
@@ -975,8 +975,8 @@
       },
       "info": {
         "default": {
-          "value": "#037DD6",
-          "description": "(blue500: #037DD6) For informational semantic elements. Used for text, background, icon or border",
+          "value": "#0376C9",
+          "description": "(blue500: #0376C9) For informational semantic elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -985,8 +985,8 @@
           "type": "color"
         },
         "muted": {
-          "value": "#037DD619",
-          "description": "(blue500: #037DD6 10% opacity) For lowest contrast background used in informational semantic. (Example: notification background)",
+          "value": "#0376C919",
+          "description": "(blue500: #0376C9 10% opacity) For lowest contrast background used in informational semantic. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
@@ -995,8 +995,8 @@
           "type": "color"
         },
         "disabled": {
-          "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) [DEPRECATED] primary.disabled should be used for all disabled primary action components such as buttons or links",
+          "value": "#0376C980",
+          "description": "(blue500: #0376C9 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       },
@@ -1106,7 +1106,7 @@
           "y": "2",
           "blur": "8",
           "spread": "0",
-          "color": "#037DD633",
+          "color": "#0376C933",
           "type": "dropShadow"
         },
         "type": "boxShadow",
@@ -1380,8 +1380,8 @@
           "type": "color"
         },
         "disabled": {
-          "value": "#037DD680",
-          "description": "(blue500: #037DD6 50% opacity) [DEPRECATED] info.disabled should be used for all disabled info action components such as buttons or links",
+          "value": "#0376C980",
+          "description": "(blue500: #0376C9 50% opacity) [Deprecated] info.disabled should be used for all disabled info action components such as buttons or links",
           "type": "color"
         }
       },

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -861,7 +861,7 @@
         },
         "disabled": {
           "value": "#0376C980",
-          "description": "(blue500: #0376C9 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
+          "description": "(blue500: #0376C9 50% opacity) [DEPRECATED] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       },
@@ -915,7 +915,7 @@
         },
         "disabled": {
           "value": "#D7384780",
-          "description": "(red500: #D73847 50% opacity) [Deprecated] error.disabled should be used for all disabled critical action components such as buttons",
+          "description": "(red500: #D73847 50% opacity) [DEPRECATED] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
@@ -996,7 +996,7 @@
         },
         "disabled": {
           "value": "#0376C980",
-          "description": "(blue500: #0376C9 50% opacity) [Deprecated] primary.disabled should be used for all disabled primary action components such as buttons or links",
+          "description": "(blue500: #0376C9 50% opacity) [DEPRECATED] primary.disabled should be used for all disabled primary action components such as buttons or links",
           "type": "color"
         }
       },
@@ -1300,7 +1300,7 @@
         },
         "disabled": {
           "value": "#D7384780",
-          "description": "(red500: #D73847 50% opacity) [Deprecated] error.disabled should be used for all disabled critical action components such as buttons",
+          "description": "(red500: #D73847 50% opacity) [DEPRECATED] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
@@ -1381,7 +1381,7 @@
         },
         "disabled": {
           "value": "#0376C980",
-          "description": "(blue500: #0376C9 50% opacity) [Deprecated] info.disabled should be used for all disabled info action components such as buttons or links",
+          "description": "(blue500: #0376C9 50% opacity) [DEPRECATED] info.disabled should be used for all disabled info action components such as buttons or links",
           "type": "color"
         }
       },

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -265,8 +265,8 @@
           "type": "color"
         },
         "red500": {
-          "value": "#D73A49",
-          "description": "(HEX: #D73A49)",
+          "value": "#D73847",
+          "description": "(HEX: #D73847)",
           "type": "color"
         },
         "red600": {
@@ -894,8 +894,8 @@
       },
       "error": {
         "default": {
-          "value": "#D73A49",
-          "description": "(red500: #D73A49) For high-level alert danger/critical elements. Used for text, background, icon or border",
+          "value": "#D73847",
+          "description": "(red500: #D73847) For high-level alert danger/critical elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -904,8 +904,8 @@
           "type": "color"
         },
         "muted": {
-          "value": "#D73A4919",
-          "description": "(red500: #D73A49 10% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
+          "value": "#D7384719",
+          "description": "(red500: #D73847 10% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
@@ -914,8 +914,8 @@
           "type": "color"
         },
         "disabled": {
-          "value": "#D73A4980",
-          "description": "(red500: #D73A49 50% opacity) [DEPRECATED] error.disabled should be used for all disabled critical action components such as buttons",
+          "value": "#D7384780",
+          "description": "(red500: #D73847 50% opacity) [Deprecated] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
@@ -1118,7 +1118,7 @@
           "y": "2",
           "blur": "8",
           "spread": "0",
-          "color": "#D73A4966",
+          "color": "#D7384766",
           "type": "dropShadow"
         },
         "type": "boxShadow",
@@ -1279,8 +1279,8 @@
       },
       "error": {
         "default": {
-          "value": "#D73A49",
-          "description": "(red500: #D73A49) For high-level alert danger/critical elements. Used for text, background, icon or border",
+          "value": "#D73847",
+          "description": "(red500: #D73847) For high-level alert danger/critical elements. Used for text, background, icon or border",
           "type": "color"
         },
         "alternative": {
@@ -1289,8 +1289,8 @@
           "type": "color"
         },
         "muted": {
-          "value": "#D73A4926",
-          "description": "(red500: #D73A49 15% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
+          "value": "#D7384726",
+          "description": "(red500: #D73847 15% opacity) For lowest contrast background used in high-level alert danger/critical elements. (Example: notification background)",
           "type": "color"
         },
         "inverse": {
@@ -1299,8 +1299,8 @@
           "type": "color"
         },
         "disabled": {
-          "value": "#D73A4980",
-          "description": "(red500: #D73A49 50% opacity) [DEPRECATED] error.disabled should be used for all disabled critical action components such as buttons",
+          "value": "#D7384780",
+          "description": "(red500: #D73847 50% opacity) [Deprecated] error.disabled should be used for all disabled critical action components such as buttons",
           "type": "color"
         }
       },
@@ -1494,7 +1494,7 @@
       },
       "error": {
         "value": {
-          "color": "#D73A4966",
+          "color": "#D7384766",
           "type": "dropShadow",
           "x": "0",
           "y": "7",

--- a/src/js/themes/darkTheme/colors.ts
+++ b/src/js/themes/darkTheme/colors.ts
@@ -51,12 +51,12 @@ export const colors: ThemeColors = {
     disabled: '#F8883B80',
   },
   error: {
-    default: '#D73A49',
+    default: '#D73847',
     alternative: '#E06470',
-    muted: '#D73A4926',
+    muted: '#D7384726',
     inverse: '#FCFCFC',
-    disabled: '#D73A4980',
-    shadow: '#D73A4966',
+    disabled: '#D7384780',
+    shadow: '#D7384766',
   },
   warning: {
     default: '#FFD33D',

--- a/src/js/themes/darkTheme/colors.ts
+++ b/src/js/themes/darkTheme/colors.ts
@@ -77,7 +77,7 @@ export const colors: ThemeColors = {
     alternative: '#43AEFC',
     muted: '#1098FC26',
     inverse: '#FCFCFC',
-    disabled: '#037DD680',
+    disabled: '#0376C980',
   },
   networks: {
     goerli: {

--- a/src/js/themes/lightTheme/colors.ts
+++ b/src/js/themes/lightTheme/colors.ts
@@ -51,12 +51,12 @@ export const colors: ThemeColors = {
     disabled: '#F66A0A80',
   },
   error: {
-    default: '#D73A49',
+    default: '#D73847',
     alternative: '#B92534',
-    muted: '#D73A4919',
+    muted: '#D7384719',
     inverse: '#FCFCFC',
-    disabled: '#D73A4980',
-    shadow: '#D73A4966',
+    disabled: '#D7384780',
+    shadow: '#D7384766',
   },
   warning: {
     default: '#F66A0A',

--- a/src/js/themes/lightTheme/colors.ts
+++ b/src/js/themes/lightTheme/colors.ts
@@ -36,12 +36,12 @@ export const colors: ThemeColors = {
     default: '#0000001A',
   },
   primary: {
-    default: '#037DD6',
+    default: '#0376C9',
     alternative: '#0260A4',
-    muted: '#037DD619',
+    muted: '#0376C919',
     inverse: '#FCFCFC',
-    disabled: '#037DD680',
-    shadow: '#037DD633',
+    disabled: '#0376C980',
+    shadow: '#0376C933',
   },
   secondary: {
     default: '#F66A0A',
@@ -73,11 +73,11 @@ export const colors: ThemeColors = {
     disabled: '#28A74580',
   },
   info: {
-    default: '#037DD6',
+    default: '#0376C9',
     alternative: '#0260A4',
-    muted: '#037DD619',
+    muted: '#0376C919',
     inverse: '#FCFCFC',
-    disabled: '#037DD680',
+    disabled: '#0376C980',
   },
   networks: {
     goerli: {


### PR DESCRIPTION
### Description
Currently our primary/default and error/default colors were not passing AA accessibility standards because it was not meeting the contrast ratio of `4.5`. This is a problem because it impacts visually impaired users.

This PR updates blue500 and red500 which are used for the primary/default and error/default color tokens respectively. It also updates any related tokens such as info/default, muted, disabled and shadow

Fixes #253 

### Screenshots

## Before

<img width="1440" alt="Screenshot 2022-11-24 at 1 26 19 PM" src="https://user-images.githubusercontent.com/8112138/203865848-6d733e69-f89a-4f97-a77e-2da3f1a6c2bf.png">
<img width="1440" alt="Screenshot 2022-11-24 at 1 28 56 PM" src="https://user-images.githubusercontent.com/8112138/203865861-a2bf24e2-a643-4f45-8e0a-5cccf8024ef3.png">
<img width="1440" alt="Screenshot 2022-11-24 at 1 29 30 PM" src="https://user-images.githubusercontent.com/8112138/203865880-f0594b1a-0b63-4ee2-b458-e3abc51120f1.png">
<img width="1440" alt="Screenshot 2022-11-24 at 1 31 56 PM" src="https://user-images.githubusercontent.com/8112138/203865893-168be3fe-f5f3-41ca-9e6a-8736aeeeee96.png">
<img width="1439" alt="Screenshot 2022-11-24 at 1 32 37 PM" src="https://user-images.githubusercontent.com/8112138/203865901-520ea6ed-0d41-439a-8bdc-7004ddd1dc21.png">
<img width="1440" alt="Screenshot 2022-11-24 at 1 34 54 PM" src="https://user-images.githubusercontent.com/8112138/203865913-8b7d60d5-0759-41bf-8a9d-7555b2fd69db.png">


## After

<img width="1436" alt="Screenshot 2022-11-24 at 1 27 39 PM" src="https://user-images.githubusercontent.com/8112138/203865937-e11fabb4-054f-4454-bd09-32866308f21b.png">
<img width="1440" alt="Screenshot 2022-11-24 at 1 28 25 PM" src="https://user-images.githubusercontent.com/8112138/203865948-e88546e7-1851-4c94-a589-c3e21706c8b3.png">
<img width="1439" alt="Screenshot 2022-11-24 at 1 30 19 PM" src="https://user-images.githubusercontent.com/8112138/203865963-fb0bc272-8fba-4f0e-9d62-25464e1b3064.png">
<img width="1439" alt="Screenshot 2022-11-24 at 1 30 56 PM" src="https://user-images.githubusercontent.com/8112138/203865988-7e45566a-451f-48ed-a110-e226d6ecabca.png">
<img width="1439" alt="Screenshot 2022-11-24 at 1 33 23 PM" src="https://user-images.githubusercontent.com/8112138/203866005-1f1d02c6-c2b0-4664-8468-1a0915ee4568.png">
<img width="1439" alt="Screenshot 2022-11-24 at 1 34 24 PM" src="https://user-images.githubusercontent.com/8112138/203866017-a259bcfd-38db-4dc8-abf3-fe3f6635bde3.png">

## Manual testing steps
- Go to the latest build of storybook on this PR
- Check all colors have been updated correctly
- Check out this branch and do a search for `#037DD6` there should be no results