### PR TITLE
feat: new design system variables for linea network

### DIFF
--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -298,6 +298,8 @@
   --color-network-localhost-inverse: var(--brand-colors-white-white010);
   --color-network-sepolia-default: var(--brand-colors-violet-violet300);
   --color-network-sepolia-inverse: var(--brand-colors-white-white010);
+  --color-network-linea-default: var(--brand-colors-black-black000);
+  --color-network-linea-inverse: var(--brand-colors-white-white010);
   --color-flask-default: var(--brand-colors-purple-purple500);
   --color-flask-inverse: var(--brand-colors-white-white010);
 


### PR DESCRIPTION
Added new design system variables for Linea network to be able to use them in the metamask extension repo
- `--color-network-linea-default`
- `--color-network-linea-inverse`