### PR TITLE
Hover & Pressed color updates

### DIFF
--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -273,11 +273,13 @@
 
 :root {
   --color-background-default: var(--brand-colors-white-white000);
-  --color-background-default-hover: var(--brand-colors-grey-grey030);
-  --color-background-default-pressed: var(--brand-colors-grey-grey030);
+  --color-background-default-hover: #fafafa;
+  --color-background-default-pressed: #ebebeb;
   --color-background-alternative: var(--brand-colors-grey-grey040);
-  --color-background-alternative-hover: var(--brand-colors-grey-grey100);
-  --color-background-alternative-pressed: var(--brand-colors-grey-grey100);
+  --color-background-alternative-hover: #edeff1;
+  --color-background-alternative-pressed: #dfe0e2;
+  --color-background-hover: #00000005;
+  --color-background-pressed: #00000014;
   --color-text-default: var(--brand-colors-grey-grey800);
   --color-text-alternative: var(--brand-colors-grey-grey600);
   --color-text-muted: var(--brand-colors-grey-grey200);
@@ -346,11 +348,13 @@
 
 [data-theme='dark'] {
   --color-background-default: var(--brand-colors-grey-grey800);
-  --color-background-default-hover: var(--brand-colors-grey-grey700);
-  --color-background-default-pressed: var(--brand-colors-grey-grey700);
+  --color-background-default-hover: #282b2e;
+  --color-background-default-pressed: #36383b;
   --color-background-alternative: var(--brand-colors-grey-grey900);
-  --color-background-alternative-hover: var(--brand-colors-grey-grey750);
-  --color-background-alternative-pressed: var(--brand-colors-grey-grey750);
+  --color-background-alternative-hover: #191b1d;
+  --color-background-alternative-pressed: #27292a;
+  --color-background-hover: #ffffff05;
+  --color-background-pressed: #ffffff14;
   --color-text-default: var(--brand-colors-white-white000);
   --color-text-alternative: var(--brand-colors-grey-grey100);
   --color-text-muted: var(--brand-colors-grey-grey400);

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -828,14 +828,14 @@
           "type": "color"
         },
         "default-hover": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) (grey030: #FAFBFC) For component hover states that use background/default",
-          "type": "color"
+          "value": "#FAFAFA",
+          "type": "color",
+          "description": "(#FAFAFA)For component hover states that use background/default"
         },
         "default-pressed": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) For component pressed states that use background/default",
-          "type": "color"
+          "value": "#EBEBEB",
+          "type": "color",
+          "description": "(#EBEBEB) For component pressed states that use background/default"
         },
         "alternative": {
           "value": "#F2F4F6",
@@ -843,14 +843,24 @@
           "type": "color"
         },
         "alternative-hover": {
-          "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) For component hover states that use background/alternative",
-          "type": "color"
+          "value": "#EDEFF1",
+          "type": "color",
+          "description": "(#EDEFF1) For component hover states that use background/alternative"
         },
         "alternative-pressed": {
-          "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) For component pressed states that use background/alternative",
-          "type": "color"
+          "value": "#DFE0E2)",
+          "type": "color",
+          "description": "(#DFE0E2)) For component pressed states that use background/alternative"
+        },
+        "hover": {
+          "value": "#00000005",
+          "type": "color",
+          "description": "For component hover states with no background color"
+        },
+        "pressed": {
+          "value": "#00000014",
+          "type": "color",
+          "description": "For component pressed states with no background color"
         }
       },
       "text": {

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -855,7 +855,7 @@
         "hover": {
           "value": "#00000005",
           "type": "color",
-          "description": "For component hover states with no background color"
+          "description": "(#00000005) For component hover states with no background color"
         },
         "pressed": {
           "value": "#00000014",

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -1255,7 +1255,7 @@
         "pressed": {
           "value": "#FFFFFF14",
           "type": "color",
-          "description": "For component pressed states with no background color"
+          "description": "(#FFFFFF14) For component pressed states with no background color"
         }
       },
       "text": {

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -860,7 +860,7 @@
         "pressed": {
           "value": "#00000014",
           "type": "color",
-          "description": "For component pressed states with no background color"
+          "description": "(#00000014) For component pressed states with no background color"
         }
       },
       "text": {

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -1250,7 +1250,7 @@
         "hover": {
           "value": "#FFFFFF05",
           "type": "color",
-          "description": "For component hover states with no background color"
+          "description": "(#FFFFFF05) For component hover states with no background color"
         },
         "pressed": {
           "value": "#FFFFFF14",

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -828,14 +828,14 @@
           "type": "color"
         },
         "default-hover": {
-          "value": "#FAFAFA",
-          "type": "color",
-          "description": "(#FAFAFA) For component hover states that use background/default"
+          "value": "#FAFBFC",
+          "description": "(grey030: #FAFBFC) (grey030: #FAFBFC) For component hover states that use background/default",
+          "type": "color"
         },
         "default-pressed": {
-          "value": "#EBEBEB",
-          "type": "color",
-          "description": "(#EBEBEB) For component pressed states that use background/default"
+          "value": "#FAFBFC",
+          "description": "(grey030: #FAFBFC) For component pressed states that use background/default",
+          "type": "color"
         },
         "alternative": {
           "value": "#F2F4F6",
@@ -843,24 +843,14 @@
           "type": "color"
         },
         "alternative-hover": {
-          "value": "#EDEFF1",
-          "type": "color",
-          "description": "(#EDEFF1) For component hover states that use background/alternative"
+          "value": "#D6D9DC",
+          "description": "(grey100: #D6D9DC) For component hover states that use background/alternative",
+          "type": "color"
         },
         "alternative-pressed": {
-          "value": "#DFE0E2",
-          "type": "color",
-          "description": "(#DFE0E2) For component pressed states that use background/alternative"
-        },
-        "hover": {
-          "value": "rgba(0,0,0,0.04)",
-          "type": "color",
-          "description": "For hover state of components with no background color."
-        },
-        "pressed": {
-          "value": "rgba(0,0,0,0.08)",
-          "type": "color",
-          "description": "For pressed state of components with no background color."
+          "value": "#D6D9DC",
+          "description": "(grey100: #D6D9DC) For component pressed states that use background/alternative",
+          "type": "color"
         }
       },
       "text": {
@@ -1223,14 +1213,14 @@
           "type": "color"
         },
         "default-hover": {
-          "value": "#3B4046",
-          "description": "(grey700: #3B4046) For component hover states that use background/default",
-          "type": "color"
+          "value": "#282B2E",
+          "type": "color",
+          "description": "(#282B2E) For component hover states that use background/default"
         },
         "default-pressed": {
-          "value": "#3B4046",
-          "description": "(grey700: #3B4046) For component pressed states that use background/default",
-          "type": "color"
+          "value": "#36383B",
+          "type": "color",
+          "description": "(#36383B) For component pressed states that use background/default"
         },
         "alternative": {
           "value": "#141618",
@@ -1238,14 +1228,24 @@
           "type": "color"
         },
         "alternative-hover": {
-          "value": "#2E3339",
-          "description": "(grey750: #2E3339) For component hover states that use background/alternative",
-          "type": "color"
+          "value": "#191B1D",
+          "type": "color",
+          "description": "(#191B1D) For component hover states that use background/alternative"
         },
         "alternative-pressed": {
-          "value": "#2E3339",
-          "description": "(grey750: #2E3339) For component pressed states that use background/alternative",
-          "type": "color"
+          "value": "#27292A",
+          "type": "color",
+          "description": "(#27292A) For component pressed states that use background/alternative"
+        },
+        "hover": {
+          "value": "#FFFFFF05",
+          "type": "color",
+          "description": "For component hover states with no background color"
+        },
+        "pressed": {
+          "value": "#FFFFFF14",
+          "type": "color",
+          "description": "For component pressed states with no background color"
         }
       },
       "text": {

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -848,9 +848,9 @@
           "description": "(#EDEFF1) For component hover states that use background/alternative"
         },
         "alternative-pressed": {
-          "value": "#DFE0E2)",
+          "value": "#DFE0E2",
           "type": "color",
-          "description": "(#DFE0E2)) For component pressed states that use background/alternative"
+          "description": "(#DFE0E2) For component pressed states that use background/alternative"
         },
         "hover": {
           "value": "#00000005",
@@ -1605,10 +1605,6 @@
   },
   "$themes": [],
   "$metadata": {
-    "tokenSetOrder": [
-      "global",
-      "light",
-      "dark"
-    ]
+    "tokenSetOrder": ["global", "light", "dark"]
   }
 }

--- a/src/figma/tokens.json
+++ b/src/figma/tokens.json
@@ -828,14 +828,14 @@
           "type": "color"
         },
         "default-hover": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) (grey030: #FAFBFC) For component hover states that use background/default",
-          "type": "color"
+          "value": "#FAFAFA",
+          "type": "color",
+          "description": "(#FAFAFA) For component hover states that use background/default"
         },
         "default-pressed": {
-          "value": "#FAFBFC",
-          "description": "(grey030: #FAFBFC) For component pressed states that use background/default",
-          "type": "color"
+          "value": "#EBEBEB",
+          "type": "color",
+          "description": "(#EBEBEB) For component pressed states that use background/default"
         },
         "alternative": {
           "value": "#F2F4F6",
@@ -843,14 +843,24 @@
           "type": "color"
         },
         "alternative-hover": {
-          "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) For component hover states that use background/alternative",
-          "type": "color"
+          "value": "#EDEFF1",
+          "type": "color",
+          "description": "(#EDEFF1) For component hover states that use background/alternative"
         },
         "alternative-pressed": {
-          "value": "#D6D9DC",
-          "description": "(grey100: #D6D9DC) For component pressed states that use background/alternative",
-          "type": "color"
+          "value": "#DFE0E2",
+          "type": "color",
+          "description": "(#DFE0E2) For component pressed states that use background/alternative"
+        },
+        "hover": {
+          "value": "rgba(0,0,0,0.04)",
+          "type": "color",
+          "description": "For hover state of components with no background color."
+        },
+        "pressed": {
+          "value": "rgba(0,0,0,0.08)",
+          "type": "color",
+          "description": "For pressed state of components with no background color."
         }
       },
       "text": {
@@ -1585,6 +1595,10 @@
   },
   "$themes": [],
   "$metadata": {
-    "tokenSetOrder": ["global", "light", "dark"]
+    "tokenSetOrder": [
+      "global",
+      "light",
+      "dark"
+    ]
   }
 }

--- a/src/js/themes/darkTheme/colors.test.ts
+++ b/src/js/themes/darkTheme/colors.test.ts
@@ -40,6 +40,18 @@ describe('Dark Theme Colors', () => {
     );
   });
 
+  it('js tokens for background.hover matches figma tokens background.hover', () => {
+    expect(importableColors.background.hover).toStrictEqual(
+      designTokens.dark.colors.background.hover.value,
+    );
+  });
+
+  it('js tokens for background.pressed matches figma tokens background.pressed', () => {
+    expect(importableColors.background.pressed).toStrictEqual(
+      designTokens.dark.colors.background.pressed.value,
+    );
+  });
+
   it('js tokens for text.default matches figma tokens text.default', () => {
     expect(importableColors.text.default).toStrictEqual(
       designTokens.dark.colors.text.default.value,

--- a/src/js/themes/darkTheme/colors.ts
+++ b/src/js/themes/darkTheme/colors.ts
@@ -7,11 +7,13 @@ import { ThemeColors } from '../types';
 export const colors: ThemeColors = {
   background: {
     default: '#24272A',
-    defaultHover: '#3B4046',
-    defaultPressed: '#3B4046',
+    defaultHover: '#282B2E',
+    defaultPressed: '#36383B',
     alternative: '#141618',
-    alternativeHover: '#2E3339',
-    alternativePressed: '#2E3339',
+    alternativeHover: '#191B1D',
+    alternativePressed: '#27292A',
+    hover: '#FFFFFF05',
+    pressed: '#FFFFFF14',
   },
   text: {
     default: '#FFFFFF',

--- a/src/js/themes/lightTheme/colors.test.ts
+++ b/src/js/themes/lightTheme/colors.test.ts
@@ -40,6 +40,18 @@ describe('Light Theme Colors', () => {
     );
   });
 
+  it('js tokens for background.hover matches figma tokens background.hover', () => {
+    expect(importableColors.background.hover).toStrictEqual(
+      designTokens.light.colors.background.hover.value,
+    );
+  });
+
+  it('js tokens for background.pressed matches figma tokens background.pressed', () => {
+    expect(importableColors.background.pressed).toStrictEqual(
+      designTokens.light.colors.background.pressed.value,
+    );
+  });
+
   it('js tokens for text.default matches figma tokens text.default', () => {
     expect(importableColors.text.default).toStrictEqual(
       designTokens.light.colors.text.default.value,

--- a/src/js/themes/lightTheme/colors.ts
+++ b/src/js/themes/lightTheme/colors.ts
@@ -7,11 +7,13 @@ import { ThemeColors } from '../types';
 export const colors: ThemeColors = {
   background: {
     default: '#FFFFFF',
-    defaultHover: '#FAFBFC',
-    defaultPressed: '#FAFBFC',
+    defaultHover: '#FAFAFA',
+    defaultPressed: '#EBEBEB',
     alternative: '#F2F4F6',
-    alternativeHover: '#D6D9DC',
-    alternativePressed: '#D6D9DC',
+    alternativeHover: '#EDEFF1',
+    alternativePressed: '#DFE0E2',
+    hover: '#00000005',
+    pressed: '#00000014',
   },
   text: {
     default: '#24272A',

--- a/src/js/themes/types.ts
+++ b/src/js/themes/types.ts
@@ -47,6 +47,14 @@ export interface ThemeColors {
      * {string} background.alternativePressed - For component pressed states that use background/alternative
      */
     alternativePressed: string;
+    /**
+     * {string} background.hover - For component hover states that don't have a background color
+     */
+    hover: string;
+    /**
+     * {string} background.pressed - For component pressed states that don't have a background color
+     */
+    pressed: string;
   };
   text: {
     /**


### PR DESCRIPTION
**/ Light Theme**
Added 2 new colors:
- background.hover (#000 2%)
- background.pressed (#000 8%)

Updated 4 colors:
- background.default.hover (grey030 --> #FAFAFA)
- background.default.pressed (grey030 --> #EBEBEB)
- background.alternative.hover (grey100 --> #EDEFF1)
- background.alternative.pressed (grey100 --> #DFE0E2)
<img width="1043" alt="image" src="https://github.com/MetaMask/design-tokens/assets/55973039/ab8e73b6-70c5-46fd-bba9-9b4e2c2b99b7">

**/ Dark Theme**
Added 2 new colors:
- background.hover (#FFF 2%)
- background.pressed (#FFF 8%)

Updated 4 colors:

- background.default.hover (grey700 --> #282B2E)
- background.default.pressed (grey700 --> #36383B)
- background.alternative.hover (grey750 --> #191B1D)
- background.alternative.pressed (grey750 --> #27292A)

<img width="918" alt="image" src="https://github.com/MetaMask/design-tokens/assets/55973039/c8b09354-ca98-4057-b1b8-141e06d8609a">


