### PR TITLE
ci: fix broken build-test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: 16.x
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Tests have not actually been running in CI since #248, which introduced an error in the workflow file. This fixes that.

Note that the package currently only supports Node.js v16; extending support to v18 will be addressed separately.