### PR TITLE
Fix Broken CSS Export in Design Tokens Package

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -81,7 +81,7 @@ gen_enforced_field(WorkspaceCwd, 'exports["./package.json"]', './package.json').
 
 % The list of files included in the package must only include files generated
 % during the build step.
-gen_enforced_field(WorkspaceCwd, 'files', ['dist']).
+gen_enforced_field(WorkspaceCwd, 'files', ['dist', 'src/css/']).
 
 % If a dependency is listed under "dependencies", it should not be listed under
 % "devDependencies".

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src/css/"
   ],
   "scripts": {
     "build": "tsup --clean && yarn build:types",


### PR DESCRIPTION
## **Description**
This PR addresses the issue of the broken CSS export in the design tokens package that occurred after the v2 release. The fix ensures that the CSS export functions correctly and can be used without issues in projects that depend on it.

## **Related issues**

Fixes: #608 

## **Manual testing steps**

1. Pull this branch
2. In the root folder run `npm pack` this creates a tarball of the same format that would be sent to the registry
3. Inspect the tarbal to see the CSS file included

## **Screenshots/Recordings**

### Before
Running `npm pack` before update

https://github.com/MetaMask/design-tokens/assets/8112138/404ca78c-3921-4117-a887-757e3eb6b175

### After
Running `npm pack` after update and inspecting folder

https://github.com/MetaMask/design-tokens/assets/8112138/b95937a3-2661-4756-8d43-a1e01f613082

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [ ] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
