### PR TITLE
feat: adding data theme light attribute to stylesheet to provide dyna…

### DIFF
--- a/src/css/design-tokens.css
+++ b/src/css/design-tokens.css
@@ -5,7 +5,8 @@
  * theme compatible styles
  */
 
-:root {
+:root,
+[data-theme='light'] {
   --brand-colors-white-white000: #ffffff;
   --brand-colors-white-white010: #fcfcfc;
   --brand-colors-black-black000: #000000;


### PR DESCRIPTION
## **Description**

This PR addresses the need for flexible theme switching, as discussed in [Issue #626](https://github.com/MetaMask/design-tokens/issues/626). The motivation behind this change is to enhance user experience by allowing dynamic theme changes (light and dark modes) at any level of the application.

The solution involves updating our CSS to explicitly define light and dark mode variables and applying them using the `data-theme` attribute. This approach ensures that theme changes are seamlessly reflected across the application, regardless of the global theme setting.

## **Related issues**

Fixes: #626

## **Manual testing steps**

1. Run storybook in the extension using `yarn storybook`
2. Inspect the stylesheet of the design tokens and add `,[data-theme='light']` to `root`
3. Test the theme switch at a component level by manually adding `data-theme="light"` or `data-theme="dark"` to component containers.

## **Screenshots/Recordings**

### **After**
Screencast below shows theming not work but once the data attribute `[data-theme='light']` dynamic theming works

https://github.com/MetaMask/design-tokens/assets/8112138/7dc71a2a-1685-4c0b-8bfb-259d483630f6

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've clearly explained what problem this PR is solving and how it is solved.
- [x] I've linked related issues
- [x] I've included manual testing steps
- [x] I've included screenshots/recordings if applicable
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I’ve properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "draft".
  - [x] In case it's "ready for review", I've changed it from "draft" to "non-draft".

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.