### PR TITLE
chore: updates readme to direct to metamask-design-system monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
-<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/metamask-design-system"><code>metamask-design-system</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over. Also, please re-open PRs that are under active development in the @metamask/design-tokens.</p></td></tr></table>
+<table>
+  <tr>
+    <td>
+      <p align="center"><b>⚠️ PLEASE READ ⚠️</b></p>
+      <p align="center">
+        This package has been migrated to our
+        <a href="https://github.com/MetaMask/metamask-design-system"
+          ><code>metamask-design-system</code></a
+        >
+        monorepo, and this repository has been archived. Please note that all
+        future development and feature releases will take place in the
+        <a href="https://github.com/MetaMask/metamask-design-system"
+          ><code>metamask-design-system</code></a
+        >
+        repository.
+      </p>
+    </td>
+  </tr>
+</table>
 
 # MetaMask Design Tokens 🪙
 


### PR DESCRIPTION
## **Description**

This pull request updates the README file in the design tokens repository to finalize the migration steps outlined in the [[MetaMask Design System Package Migration Process Guide](https://github.com/MetaMask/metamask-design-system/blob/main/docs/package-migration-process-guide.md)](https://github.com/MetaMask/metamask-design-system/blob/main/docs/package-migration-process-guide.md). Specifically, it replaces the migration notice from Step A-1 with an updated message to direct users to the new repository. The notice now informs users that the repository has been archived and future development will occur in the [[MetaMask Design System repository](https://github.com/MetaMask/metamask-design-system)](https://github.com/MetaMask/metamask-design-system).

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Navigate to the source repository.
2. View the updated README file to confirm the migration notice is properly formatted and includes the correct links.

## **Screenshots/Recordings**

### **Before**

<img width="615" alt="Screenshot 2024-11-26 at 3 05 45 PM" src="https://github.com/user-attachments/assets/475c7580-c420-474a-8959-73f57e71b04c">

### **After**

<img width="630" alt="Screenshot 2024-11-26 at 3 05 26 PM" src="https://github.com/user-attachments/assets/f04e7bf1-4d81-443f-9523-37580788fca3">


## **Pre-merge author checklist**

- [x] I’ve followed [[MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md)](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g., pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings or screenshots.